### PR TITLE
fix(spliit): add necessary header for healthcheck to work

### DIFF
--- a/spliit/spliit/templates/manifests.yaml
+++ b/spliit/spliit/templates/manifests.yaml
@@ -42,14 +42,23 @@ spec:
             httpGet:
               path: /
               port: http
+              httpHeaders:
+              - name: Accept-Language
+                value: en-US
           readinessProbe:
             httpGet:
              path: /
              port: http
+             httpHeaders:
+             - name: Accept-Language
+               value: en-US
           startupProbe:
             httpGet:
               path: /
               port: http
+              httpHeaders:
+              - name: Accept-Language
+                value: en-US
             failureThreshold: 30
 ---
 apiVersion: v1


### PR DESCRIPTION
See this probable root cause issue https://github.com/spliit-app/spliit/issues/221

The bug was probably introduced with the following renovate upgrade https://github.com/dixneuf19/brassberry-gitops/commit/8a7ad9672c12a44a714e5b2c1a9850844953f5ff