### PR TITLE
fix(argocd): ignore hostUsers which is not activated on my cluster

### DIFF
--- a/argocd/argo-cd/values.yaml
+++ b/argocd/argo-cd/values.yaml
@@ -17,6 +17,12 @@ argo-cd:
       controller.status.processors: 10
       controller.operation.processors: 5
       controller.repo.server.timeout.seconds: 500
+
+    cm:
+      resource.customizations.ignoreDifferences.apps_Deployment:
+        jqPathExpressions:
+        # Currently beta in k8s, not activated on my k0s but set on logitech-media-server helm chart, causing a diff
+        - '.spec.template.spec.hostUsers' 
       
   controller:
     metrics:


### PR DESCRIPTION
This feature is currently beta in 1.30. Beta API are not activated by default anymore.
See
https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/127-user-namespaces#summary for any news.