### PR TITLE
fix(spliit): use new liveness/readiness endpoint

### DIFF
--- a/spliit/spliit/templates/manifests.yaml
+++ b/spliit/spliit/templates/manifests.yaml
@@ -40,25 +40,16 @@ spec:
               cpu: "100m"
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/health/liveness
               port: http
-              httpHeaders:
-              - name: Accept-Language
-                value: en-US
           readinessProbe:
             httpGet:
-             path: /
+             path: /api/health/readiness
              port: http
-             httpHeaders:
-             - name: Accept-Language
-               value: en-US
           startupProbe:
             httpGet:
-              path: /
+              path: /api/health/readiness
               port: http
-              httpHeaders:
-              - name: Accept-Language
-                value: en-US
             failureThreshold: 30
 ---
 apiVersion: v1

--- a/spliit/spliit/values.yaml
+++ b/spliit/spliit/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: ghcr.io/crazy-max/spliit
-  tag: 1.17.0
+  repository: ghcr.io/spliit-app/spliit
+  tag: 1.18.0
 
 postgresql:
   ## Authentication parameters


### PR DESCRIPTION
Has been fixed by https://github.com/spliit-app/spliit/pull/387/files