### PR TITLE
feat: migrate all apps from ingress-nginx to Traefik

### DIFF
--- a/gitops/argocd/argo-cd/templates/webhook-ingress.yaml
+++ b/gitops/argocd/argo-cd/templates/webhook-ingress.yaml
@@ -2,10 +2,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    traefik.ingress.kubernetes.io/service.serversscheme: "https"
   name: argocd-webhook
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
   - host: argocd.dixneuf19.fr
     http:

--- a/gitops/argocd/argo-cd/values.yaml
+++ b/gitops/argocd/argo-cd/values.yaml
@@ -70,11 +70,9 @@ argo-cd:
     ingress:
       enabled: true
       annotations:
-        nginx.ingress.kubernetes.io/auth-secret: ingress-nginx/basic-auth
-        nginx.ingress.kubernetes.io/auth-type: basic
-        # GRPC, so the CLI won't work
-        nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-      ingressClassName: nginx
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
+        traefik.ingress.kubernetes.io/service.serversscheme: "https"
+      ingressClassName: traefik
       tls: true
 
   ## Repo Server

--- a/gitops/baj/og-baj-website/templates/manifests.yaml
+++ b/gitops/baj/og-baj-website/templates/manifests.yaml
@@ -64,9 +64,9 @@ metadata:
   name: og-baj-website
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-www@kubernetescrd
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
     - host: bandajoe.dixneuf19.fr
       http:

--- a/gitops/cert-manager/cert-manager/acme-cluster-issue.yaml
+++ b/gitops/cert-manager/cert-manager/acme-cluster-issue.yaml
@@ -16,4 +16,4 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          class: traefik

--- a/gitops/cert-manager/cert-manager/staging-acme-cluster-issuer.yaml
+++ b/gitops/cert-manager/cert-manager/staging-acme-cluster-issuer.yaml
@@ -16,7 +16,7 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          class: traefik
           # ingressTemplate:
           #   metadata:
           #     annotations:

--- a/gitops/dank-face-bot/dank-face-slack-bot/values.yaml
+++ b/gitops/dank-face-bot/dank-face-slack-bot/values.yaml
@@ -22,7 +22,7 @@ generic:
     port: 80
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
     hosts:

--- a/gitops/default/cd-lna/manifests/cd-lna.yaml
+++ b/gitops/default/cd-lna/manifests/cd-lna.yaml
@@ -46,10 +46,9 @@ metadata:
   name: cd-lna
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: cd-lna-auth
+    traefik.ingress.kubernetes.io/router.middlewares: default-cd-lna-auth@kubernetescrd
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
   - host: cd-lna.dixneuf19.fr
     http:

--- a/gitops/default/cd-lna/manifests/middleware.yaml
+++ b/gitops/default/cd-lna/manifests/middleware.yaml
@@ -1,0 +1,10 @@
+# NOTE: The cd-lna-auth secret must have key "users" (not "auth") for Traefik BasicAuth.
+# If the existing secret uses key "auth", recreate it:
+#   kubectl -n default create secret generic cd-lna-auth --from-literal=users='user:$(htpasswd -nbB "" "password" | cut -d: -f2)' --dry-run=client -o yaml | kubectl apply -f -
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: cd-lna-auth
+spec:
+  basicAuth:
+    secret: cd-lna-auth

--- a/gitops/default/http-echo/values.yaml
+++ b/gitops/default/http-echo/values.yaml
@@ -10,7 +10,7 @@ generic:
     port: 80
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
     hosts:

--- a/gitops/default/whoami/whoami.yaml
+++ b/gitops/default/whoami/whoami.yaml
@@ -43,10 +43,9 @@ metadata:
   name: whoami
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: ingress-nginx/basic-auth
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
     - host: whoami.dixneuf19.fr
       http:

--- a/gitops/eternal-jukebox/eternal-jukebox/templates/manifests.yaml
+++ b/gitops/eternal-jukebox/eternal-jukebox/templates/manifests.yaml
@@ -135,7 +135,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   tls:
     - hosts:
         - eternaljukebox.dixneuf19.fr

--- a/gitops/fip/fip-slack-bot/values.yaml
+++ b/gitops/fip/fip-slack-bot/values.yaml
@@ -22,7 +22,7 @@ generic:
     port: 80
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
     hosts:

--- a/gitops/fip/fip-telegram-bot/values.yaml
+++ b/gitops/fip/fip-telegram-bot/values.yaml
@@ -18,7 +18,7 @@ generic:
     port: 80
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
     hosts:

--- a/gitops/goldilocks/goldilocks/values.yaml
+++ b/gitops/goldilocks/goldilocks/values.yaml
@@ -4,11 +4,10 @@ goldilocks:
     ingress:
       enabled: true
 
-      ingressClassName: nginx
+      ingressClassName: traefik
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
-        nginx.ingress.kubernetes.io/auth-secret: ingress-nginx/basic-auth
-        nginx.ingress.kubernetes.io/auth-type: basic
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
       hosts:
         - host: goldilocks.dixneuf19.fr
           paths:

--- a/gitops/karakeep/karakeep/values.yaml
+++ b/gitops/karakeep/karakeep/values.yaml
@@ -35,10 +35,9 @@ service:
 
 ingress:
   enabled: true
-  className: "nginx"
+  className: "traefik"
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
     - host: karakeep.dixneuf19.fr
       paths:

--- a/gitops/lms-yoshi/radioyoshi/templates/ingress.yaml
+++ b/gitops/lms-yoshi/radioyoshi/templates/ingress.yaml
@@ -3,11 +3,10 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/auth-secret: yoshi-basic-auth
-    nginx.ingress.kubernetes.io/auth-type: basic  
+    traefik.ingress.kubernetes.io/router.middlewares: lms-yoshi-yoshi-basic-auth@kubernetescrd
   name: lms
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
     - host: radioyoshi.dixneuf19.fr
       http:

--- a/gitops/lms-yoshi/radioyoshi/templates/middleware.yaml
+++ b/gitops/lms-yoshi/radioyoshi/templates/middleware.yaml
@@ -1,0 +1,8 @@
+# NOTE: The yoshi-basic-auth secret must have key "users" (not "auth") for Traefik BasicAuth.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: yoshi-basic-auth
+spec:
+  basicAuth:
+    secret: yoshi-basic-auth

--- a/gitops/lms/lyrion-music-server/templates/ingress.yaml
+++ b/gitops/lms/lyrion-music-server/templates/ingress.yaml
@@ -3,12 +3,11 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/auth-secret: ingress-nginx/basic-auth
-    nginx.ingress.kubernetes.io/auth-type: basic
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
   name: lms
   namespace: lms
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
   - host: lms.dixneuf19.fr
     http:

--- a/gitops/monitoring/karma/values.yaml
+++ b/gitops/monitoring/karma/values.yaml
@@ -22,11 +22,10 @@ generic:
     port: 8080
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-      nginx.ingress.kubernetes.io/auth-secret: ingress-nginx/basic-auth
-      nginx.ingress.kubernetes.io/auth-type: basic
+      traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
     hosts:
       - host: karma.dixneuf19.fr
         paths:

--- a/gitops/monitoring/kps/values.yaml
+++ b/gitops/monitoring/kps/values.yaml
@@ -21,15 +21,15 @@ kube-prometheus-stack:
       dashboardproviders.yaml:
         apiVersion: 1
         providers:
-          - name: nginx
+          - name: traefik
             orgId: 1
             type: file
-            folder: NGINX
+            folder: Traefik
             disableDeletion: false
             editable: false
             allowUiUpdates: false
             options:
-              path: /var/lib/grafana/dashboards/nginx
+              path: /var/lib/grafana/dashboards/traefik
           - name: vpa
             orgId: 1
             type: file
@@ -59,11 +59,11 @@ kube-prometheus-stack:
 
     # Organise dashboards by provider, with the provider's name as the key.
     dashboards:
-      nginx: # The "nginx" provider is defined above.
-        nginx-ingress-controller:
-          url: https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/grafana/dashboards/nginx.json
-        ingress-request-performance:
-          url: https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/grafana/dashboards/request-handling-performance.json
+      traefik:
+        traefik-official:
+          gnetId: 17346 # https://grafana.com/grafana/dashboards/17346-traefik-official-standalone-dashboard
+          revision: 9
+          datasource: Prometheus
       vpa:
         vpa-recommendations:
           gnetId: 14588 # https://grafana.com/grafana/dashboards/14588-vpa-recommendations
@@ -121,11 +121,10 @@ kube-prometheus-stack:
 
     ingress:
       enabled: true
-      ingressClassName: nginx
+      ingressClassName: traefik
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
-        nginx.ingress.kubernetes.io/auth-type: basic
-        nginx.ingress.kubernetes.io/auth-secret: ingress-nginx/basic-auth
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
       labels: {}
       hosts:
         - grafana.dixneuf19.fr
@@ -165,11 +164,10 @@ kube-prometheus-stack:
 
     ingress:
       enabled: true
-      ingressClassName: nginx
+      ingressClassName: traefik
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
-        nginx.ingress.kubernetes.io/auth-type: basic
-        nginx.ingress.kubernetes.io/auth-secret: ingress-nginx/basic-auth
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
       labels: {}
       hosts:
         - prometheus.dixneuf19.fr

--- a/gitops/netflix/_deluge/manifests/deployment.yaml
+++ b/gitops/netflix/_deluge/manifests/deployment.yaml
@@ -51,10 +51,9 @@ metadata:
   name: deluge
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: ingress-nginx/basic-auth
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
   - host: deluge.dixneuf19.fr
     http:

--- a/gitops/netflix/_rutorrent/manifests/rutorrent.yaml
+++ b/gitops/netflix/_rutorrent/manifests/rutorrent.yaml
@@ -63,10 +63,9 @@ metadata:
   name: rutorrent
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: ingress-nginx/basic-auth
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
   - host: rutorrent.dixneuf19.fr
     http:

--- a/gitops/netflix/files/files.yaml
+++ b/gitops/netflix/files/files.yaml
@@ -46,10 +46,9 @@ metadata:
   name: files
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: files-auth
+    traefik.ingress.kubernetes.io/router.middlewares: default-files-auth@kubernetescrd
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
   - host: files.dixneuf19.fr
     http:

--- a/gitops/netflix/jellyfin/jellyfin-ingress.yaml
+++ b/gitops/netflix/jellyfin/jellyfin-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
   - host: netflix.dixneuf19.fr
     http:

--- a/gitops/netflix/transmission/manifests/deployment.yaml
+++ b/gitops/netflix/transmission/manifests/deployment.yaml
@@ -88,10 +88,9 @@ metadata:
   name: transmission
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: ingress-nginx/basic-auth
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
   - host: transmission.dixneuf19.fr
     http:

--- a/gitops/readeck/readeck/manifests.yaml
+++ b/gitops/readeck/readeck/manifests.yaml
@@ -105,9 +105,9 @@ metadata:
   name: readeck
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-body-size-50m@kubernetescrd
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   tls:
     - hosts:
         - readeck.dixneuf19.fr

--- a/gitops/soundhoard/navidrome/values.yaml
+++ b/gitops/soundhoard/navidrome/values.yaml
@@ -1,0 +1,34 @@
+navidrome:
+  env:
+    ND_MUSICFOLDER: /music
+    ND_LOGLEVEL: info
+    ND_SCANSCHEDULE: "@every 1m"
+
+  ingress:
+    main:
+      enabled: true
+      ingressClassName: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+      hosts:
+        - host: navidrome.dixneuf19.fr
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: navidrome-tls
+          hosts:
+            - navidrome.dixneuf19.fr
+
+  persistence:
+    config:
+      enabled: true
+      mountPath: /data
+      storageClass: nfs-client
+      accessMode: ReadWriteMany
+      size: 1Mi
+    music:
+      enabled: true
+      mountPath: /music
+      existingClaim: soundhoard-music
+      readOnly: true

--- a/gitops/spliit/spliit/templates/manifests.yaml
+++ b/gitops/spliit/spliit/templates/manifests.yaml
@@ -70,7 +70,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
   - host: spliit.dixneuf19.fr
     http:

--- a/gitops/tools/librespeed/manifests/svc.yaml
+++ b/gitops/tools/librespeed/manifests/svc.yaml
@@ -17,10 +17,8 @@ metadata:
   name: librespeed
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    # nginx.ingress.kubernetes.io/auth-type: basic
-    # nginx.ingress.kubernetes.io/auth-secret: ingress-nginx/basic-auth
 spec:
-  ingressClassName: nginx
+  ingressClassName: traefik
   rules:
   - host: speedtest.dixneuf19.fr
     http:


### PR DESCRIPTION
## Summary
Re-PR of #1569 which was merged into the wrong branch (stacking race condition).

Same changes: switch all apps from `ingressClassName: nginx` to `traefik`, update annotations, cert-manager issuers, Grafana dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)