### PR TITLE
fix: remove ArgoCD backend HTTPS (x509 error)

### DIFF
--- a/gitops/argocd/argo-cd/templates/servers-transport.yaml
+++ b/gitops/argocd/argo-cd/templates/servers-transport.yaml
@@ -1,6 +1,0 @@
-apiVersion: traefik.io/v1alpha1
-kind: ServersTransport
-metadata:
-  name: argocd-skip-verify
-spec:
-  insecureSkipVerify: true

--- a/gitops/argocd/argo-cd/templates/webhook-ingress.yaml
+++ b/gitops/argocd/argo-cd/templates/webhook-ingress.yaml
@@ -1,9 +1,6 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    traefik.ingress.kubernetes.io/service.serversscheme: "https"
-    traefik.ingress.kubernetes.io/service.serverstransport: argocd-argocd-skip-verify@kubernetescrd
   name: argocd-webhook
 spec:
   ingressClassName: traefik

--- a/gitops/argocd/argo-cd/values.yaml
+++ b/gitops/argocd/argo-cd/values.yaml
@@ -71,8 +71,6 @@ argo-cd:
       enabled: true
       annotations:
         traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
-        traefik.ingress.kubernetes.io/service.serversscheme: "https"
-        traefik.ingress.kubernetes.io/service.serverstransport: argocd-argocd-skip-verify@kubernetescrd
       ingressClassName: traefik
       tls: true
 


### PR DESCRIPTION
## Summary
- Remove `serversscheme: https` and `serverstransport` annotations from ArgoCD ingresses
- Delete `ServersTransport` CRD template (no longer needed)
- ArgoCD server port 80 speaks plain HTTP — the HTTPS backend was causing x509 cert validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)