### PR TITLE
fix: enable ArgoCD server insecure mode (fix x509 error)

### DIFF
--- a/gitops/argocd/argo-cd/values.yaml
+++ b/gitops/argocd/argo-cd/values.yaml
@@ -14,6 +14,7 @@ argo-cd:
   configs:
     params:
       server.disable.auth: true
+      server.insecure: true
       controller.status.processors: 10
       controller.operation.processors: 5
       controller.repo.server.timeout.seconds: 500


### PR DESCRIPTION
## Summary
ArgoCD server serves HTTPS on port 8080 with a self-signed cert. Traefik can't verify it → x509 error → 500 Internal Server Error.

Fix: set `server.insecure: true` so ArgoCD serves plain HTTP. TLS termination is handled by Traefik, not the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)