### PR TITLE
Remove unused image tags managed by argocd-image-updater

### DIFF
--- a/gitops/argocd/argocd-image-updater/templates/image-updaters.yaml
+++ b/gitops/argocd/argocd-image-updater/templates/image-updaters.yaml
@@ -24,30 +24,6 @@ spec:
     updateStrategy: "digest"
   applicationRefs:
     # fip namespace apps
-    - namePattern: "fip-slack-bot"
-      images:
-        - alias: "fip-slack-bot"
-          imageName: "ghcr.io/dixneuf19/fip-slack-bot:main"
-          manifestTargets:
-            helm:
-              name: "generic.image.name"
-              tag: "generic.image.tag"
-    - namePattern: "fip-telegram-bot"
-      images:
-        - alias: "fip-telegram-bot"
-          imageName: "ghcr.io/dixneuf19/fip-telegram-bot:master"
-          manifestTargets:
-            helm:
-              name: "generic.image.name"
-              tag: "generic.image.tag"
-    - namePattern: "spotify-api"
-      images:
-        - alias: "spotify-api"
-          imageName: "ghcr.io/dixneuf19/spotify-api:master"
-          manifestTargets:
-            helm:
-              name: "generic.image.name"
-              tag: "generic.image.tag"
     - namePattern: "whats-on-fip"
       images:
         - alias: "whats-on-fip"

--- a/gitops/dank-face-bot/dank-face-bot/values.yaml
+++ b/gitops/dank-face-bot/dank-face-bot/values.yaml
@@ -2,7 +2,6 @@ generic:
   replicaCount: 1
   image:
     repository: ghcr.io/dixneuf19/dank-face-bot
-    tag: "1d0c6e0fc8e016eb2f45d888fb462a53321e4b2d@sha256:047b957aa3ba19abe2a90a9beab84f888f4dd35f51d134602da4c0bcdd3c773f"
   container:
     noProbes: true
   resources:

--- a/gitops/dank-face-bot/dank-face-slack-bot/values.yaml
+++ b/gitops/dank-face-bot/dank-face-slack-bot/values.yaml
@@ -2,8 +2,6 @@ generic:
   replicaCount: 1
   image:
     repository: ghcr.io/dixneuf19/dank-face-slack-bot
-    tag: main@sha256:14c2efa098017188d596898e9db39d5e570e73592ee853134a7e13774ffbcf04
-    pullPolicy: Always
   container:
     port: 3000
     probe:

--- a/gitops/fip/whats-on-fip/values.yaml
+++ b/gitops/fip/whats-on-fip/values.yaml
@@ -2,8 +2,6 @@ generic:
   replicaCount: 1
   image:
     repository: ghcr.io/dixneuf19/whats-on-fip
-    tag: main@sha256:2f7a9b2801b55772ec5c8e9c32b2e331fc5a053f7f9bc5e464c1423ca97fafd0
-    pullPolicy: Always
   container:
     port: 80
     noProbes: true

--- a/gitops/soundhoard/soundhoard/values.yaml
+++ b/gitops/soundhoard/soundhoard/values.yaml
@@ -2,7 +2,6 @@ generic:
   replicaCount: 1
   image:
     repository: ghcr.io/dixneuf19/soundhoard
-    tag: main@sha256:5c1315a2ff48849f3fd59230686ef69035835c06a600529a2d3bb97751025913
   container:
     noProbes: true
   resources:

--- a/gitops/spliit/spliit/values.yaml
+++ b/gitops/spliit/spliit/values.yaml
@@ -1,4 +1,2 @@
 image:
-  # Overriden in .argocd-source-spliit.yaml
   repository: ghcr.io/spliit-app/spliit
-  tag: 1.19.0@sha256:2f0f44d58768bed6c7c9aed72f74e43a14599b459828cd87227a7c35ba29b9b8


### PR DESCRIPTION
## Summary
- Remove unused `image.tag` from `values.yaml` for apps where argocd-image-updater overrides the tag via `.argocd-source-*.yaml` git write-back (dank-face-bot, dank-face-slack-bot, whats-on-fip, soundhoard, spliit)
- Remove decommissioned apps (fip-slack-bot, fip-telegram-bot, spotify-api) from the ImageUpdater CRDs
- Also removes `pullPolicy: Always` from dank-face-slack-bot and whats-on-fip since it was co-located with the removed tag and digest-pinned images don't need it

## Context
Follow-up to #1589. The image tags in `values.yaml` are never used at runtime — argocd-image-updater writes the actual pinned digest to `.argocd-source-<app>.yaml`, which takes precedence as a Helm parameter override.

## Test plan
- [ ] ArgoCD diff in CI should show no changes for affected apps (the `.argocd-source` files still provide the tags)
- [ ] Verify argocd-image-updater continues to update images normally after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)