### PR TITLE
feat: add Grist self-hosted spreadsheet

### DIFF
--- a/gitops/argocd/apps/values.yaml
+++ b/gitops/argocd/apps/values.yaml
@@ -210,6 +210,12 @@ applications:
     path: gitops/spliit/spliit
     selfHeal: true
 
+  - name: grist
+    namespace: grist
+    path: gitops/grist/grist
+    type: directory
+    selfHeal: true
+
   - name: readeck
     namespace: readeck
     path: gitops/readeck/readeck

--- a/gitops/grist/grist/Makefile
+++ b/gitops/grist/grist/Makefile
@@ -1,0 +1,7 @@
+NAMESPACE=grist
+
+namespace:
+	kubectl create namespace "${NAMESPACE}" || echo "Namespace ${NAMESPACE} already exists"
+
+deploy: namespace
+	kubectl apply -n "${NAMESPACE}" -f .

--- a/gitops/grist/grist/deployment.yaml
+++ b/gitops/grist/grist/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grist
+  labels:
+    app.kubernetes.io/name: grist
+    app.kubernetes.io/instance: grist
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grist
+      app.kubernetes.io/instance: grist
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grist
+        app.kubernetes.io/instance: grist
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: grist
+          image: gristlabs/grist:1.7.12
+          ports:
+            - name: http
+              containerPort: 8484
+              protocol: TCP
+          env:
+            - name: GRIST_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: grist-secrets
+                  key: password
+            - name: GRIST_DEFAULT_EMAIL
+              value: "grist@dixneuf19.fr"
+            - name: GRIST_SANDBOX_FLAVOR
+              value: "gvisor"
+            - name: APP_HOME_URL
+              value: "https://grist.dixneuf19.fr"
+            - name: GRIST_SINGLE_ORG
+              value: "grist"
+          volumeMounts:
+            - name: data
+              mountPath: /persist
+          securityContext:
+            capabilities:
+              add:
+                - SYS_PTRACE
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            failureThreshold: 3
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: grist-data
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64

--- a/gitops/grist/grist/deployment.yaml
+++ b/gitops/grist/grist/deployment.yaml
@@ -67,6 +67,8 @@ spec:
             requests:
               cpu: 100m
               memory: 256Mi
+            limits:
+              memory: 512Mi
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/gitops/grist/grist/deployment.yaml
+++ b/gitops/grist/grist/deployment.yaml
@@ -73,6 +73,7 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: grist-data
+      # gvisor sandbox requires x86_64 (Sandy Bridge+), no ARM support
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/gitops/grist/grist/external-secret.yaml
+++ b/gitops/grist/grist/external-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grist-secrets
+spec:
+  refreshInterval: "0"
+  target:
+    name: grist-secrets
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: grist-session-secret

--- a/gitops/grist/grist/password-generator.yaml
+++ b/gitops/grist/grist/password-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: grist-session-secret
+spec:
+  length: 48
+  digits: 10
+  symbols: 0
+  noUpper: false
+  allowRepeat: true

--- a/gitops/grist/grist/pvc.yaml
+++ b/gitops/grist/grist/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grist-data
+  labels:
+    app.kubernetes.io/name: grist
+    app.kubernetes.io/instance: grist
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: nfs-jonbonas

--- a/gitops/grist/grist/service.yaml
+++ b/gitops/grist/grist/service.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grist
+  labels:
+    app.kubernetes.io/name: grist
+    app.kubernetes.io/instance: grist
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8484
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: grist
+    app.kubernetes.io/instance: grist
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grist
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-basic-auth@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - grist.dixneuf19.fr
+      secretName: grist-dixneuf19-fr-tls
+  rules:
+    - host: grist.dixneuf19.fr
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grist
+                port:
+                  name: http


### PR DESCRIPTION
## Summary
- Deploy [Grist](https://github.com/gristlabs/grist-core) (relational spreadsheet) as raw Kubernetes manifests
- gvisor sandboxing with amd64 node affinity (gvisor requires x86_64)
- Persistent storage on `nfs-jonbonas` (ZFS-backed, data integrity for SQLite)
- Session secret generated via ESO Password generator (first use of ESO generators in this repo)
- Access controlled by Traefik basic-auth middleware + TLS via cert-manager
- Single-org mode at `grist.dixneuf19.fr`

## Notes
- No OIDC/SAML configured yet — auth is basic-auth only for now
- `GRIST_DEFAULT_EMAIL` set to `grist@dixneuf19.fr` (placeholder for future OIDC setup)
- `GRIST_FORCE_LOGIN` intentionally not set (requires an identity provider to work)

## Test plan
- [ ] Verify ArgoCD syncs the new `grist` application
- [ ] Confirm ESO Password generator creates the `grist-secrets` secret
- [ ] Check pod schedules on an amd64 node and starts successfully
- [ ] Verify gvisor sandbox is active (check logs for sandbox messages)
- [ ] Access `grist.dixneuf19.fr` behind basic-auth
- [ ] Create a test spreadsheet with a Python formula to validate sandboxing

🤖 Generated with [Claude Code](https://claude.com/claude-code)