### PR TITLE
fix: grist health probes and forwarded auth

### DIFF
--- a/gitops/grist/grist/deployment.yaml
+++ b/gitops/grist/grist/deployment.yaml
@@ -35,11 +35,15 @@ spec:
                   name: grist-secrets
                   key: password
             - name: GRIST_DEFAULT_EMAIL
-              value: "grist@dixneuf19.fr"
+              value: "baloo"
             - name: GRIST_SANDBOX_FLAVOR
               value: "gvisor"
             - name: APP_HOME_URL
               value: "https://grist.dixneuf19.fr"
+            - name: GRIST_FORWARD_AUTH_HEADER
+              value: "X-Forwarded-User"
+            - name: GRIST_FORCE_LOGIN
+              value: "true"
             - name: GRIST_SINGLE_ORG
               value: "grist"
           volumeMounts:
@@ -51,15 +55,15 @@ spec:
                 - SYS_PTRACE
           livenessProbe:
             httpGet:
-              path: /
-              port: http
+              path: /status
+              port: 8484
             initialDelaySeconds: 10
             failureThreshold: 3
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /
-              port: http
+              path: /status
+              port: 8484
             initialDelaySeconds: 5
             failureThreshold: 3
             periodSeconds: 10


### PR DESCRIPTION
## Summary
- Switch health probes from `GET /` to `GET /status` (dedicated health endpoint, avoids auth redirects and HTTPS scheme mismatch)
- Enable Traefik basic-auth forwarded header auth (`GRIST_FORWARD_AUTH_HEADER=X-Forwarded-User`) so Grist identifies users from basic-auth — follows [official grist-traefik-basic-auth example](https://github.com/gristlabs/grist-core/tree/main/docker-compose-examples/grist-traefik-basic-auth)
- Add `GRIST_FORCE_LOGIN=true` to prevent anonymous access
- Set `GRIST_DEFAULT_EMAIL=baloo` to match basic-auth username for admin access

## Context
PR #1592 deployed Grist but the pod was crash-looping because:
1. Health probes hit `/` which triggered auth redirects (non-200)
2. Kubelet was using HTTPS scheme for probes (port name issue)
3. `GRIST_SINGLE_ORG` requires an identified user, not anonymous

## Test plan
- [ ] Pod starts and stays healthy (no restarts)
- [ ] `/status` probe returns 200
- [ ] Access `grist.dixneuf19.fr` — basic-auth prompt, then Grist UI
- [ ] Verify admin panel is accessible (user "baloo" = admin)
- [ ] Confirm single-org mode works (no org picker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)