### PR TITLE
fix: simplify grist auth config

### DIFF
--- a/gitops/grist/grist/deployment.yaml
+++ b/gitops/grist/grist/deployment.yaml
@@ -35,17 +35,11 @@ spec:
                   name: grist-secrets
                   key: password
             - name: GRIST_DEFAULT_EMAIL
-              value: "baloo"
+              value: "grist@dixneuf19.fr"
             - name: GRIST_SANDBOX_FLAVOR
               value: "gvisor"
             - name: APP_HOME_URL
               value: "https://grist.dixneuf19.fr"
-            - name: GRIST_FORWARD_AUTH_HEADER
-              value: "X-Forwarded-User"
-            - name: GRIST_FORCE_LOGIN
-              value: "true"
-            - name: GRIST_SINGLE_ORG
-              value: "grist"
           volumeMounts:
             - name: data
               mountPath: /persist


### PR DESCRIPTION
## Summary
- Remove `GRIST_FORWARD_AUTH_HEADER`, `GRIST_FORCE_LOGIN`, `GRIST_SINGLE_ORG` — don't work without a proper IdP
- Restore `GRIST_DEFAULT_EMAIL` to `grist@dixneuf19.fr`
- Auth stays at ingress level (Traefik basic-auth)

## Test plan
- [ ] Pod stays healthy
- [ ] Access `grist.dixneuf19.fr` — basic-auth then Grist UI loads without "cannot find user" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)