### PR TITLE
fix(proxmox): import fastpool at boot so k8s-worker-1 starts

### DIFF
--- a/proxmox/playbooks/proxmox-zfs.yaml
+++ b/proxmox/playbooks/proxmox-zfs.yaml
@@ -36,6 +36,11 @@
         pool_properties:
           ashift: "12"
           autoexpand: "on"
+          # Must be in the cachefile so zfs-import-cache.service imports it at boot,
+          # before pve-guests.service starts the VMs. Without it PVE imports the pool
+          # lazily from inside qmstart (with -o cachefile=none, which is self-perpetuating)
+          # and the VM start fails. See proxmox/ZFS.md.
+          cachefile: /etc/zfs/zpool.cache
         filesystem_properties:
           compression: lz4
           atime: "off"
@@ -63,6 +68,9 @@
         pool_properties:
           ashift: "12"
           autoexpand: "on"
+          # Declared explicitly rather than relying on the default, so the boot-import
+          # invariant is stated for every pool PVE has storages on (see fastpool above).
+          cachefile: /etc/zfs/zpool.cache
         filesystem_properties:
           compression: zstd
           atime: "off"

--- a/proxmox/terraform/vms.tf
+++ b/proxmox/terraform/vms.tf
@@ -73,6 +73,13 @@ resource "proxmox_virtual_environment_vm" "k8s_worker" {
   # Start on boot
   on_boot = true
 
+  # Start order. No up_delay: it delays the NEXT guest, not this one, so it never
+  # helped the fastpool import race it was added for. fastpool is now imported at
+  # boot via zpool.cache instead (see playbooks/proxmox-zfs.yaml).
+  startup {
+    order = 1
+  }
+
   # Start immediately after creation
   started = true
 


### PR DESCRIPTION
## Problem

VM 200 (`k8s-worker-1`) fails to start on **every** cold boot of jonbonas:

```
zfs error: cannot open 'fastpool': no such pool

TASK ERROR: zfs error: cannot create 'fastpool/vm-disks/vm-200-cloudinit': dataset already exists
```

The last occurrence cost a **35 hour outage**. The host booted `2026-08-02 22:27:14`, the start failed 15 s later, and the worker did not run again until it was started by hand at `2026-08-04 09:24:37`. Nothing retried and nothing noticed: `startall` exits `OK` after a failed guest start, so `pve-guests.service` reports `Finished`.

## Root cause

`fastpool` carried `cachefile=none`, so it was absent from `/etc/zfs/zpool.cache` and **nothing imported it at boot**. `zfs-import-scan` is disabled, `zfs-import@` is disabled, `zfs-import.service` is masked, and `ZPOOL_IMPORT_ALL_VISIBLE='no'`.

PVE therefore imported it lazily from inside `qmstart` itself, one function call before failing on it:

| location | what happens |
|---|---|
| `QemuServer.pm:5541` | `apply_cloudinit_config`, which runs **before** `activate_volumes` at `:5611` |
| `Cloudinit.pm:42` | `volume_size_info` fails on the unimported pool, the `eval` swallows the error, `$size` is undef |
| `Cloudinit.pm:46` | so `vdisk_alloc` is called |
| `Storage.pm:1167` | `vdisk_alloc` calls `activate_storage`, which warns **error line 1**, then imports the pool with `-o cachefile=none` |
| `Storage.pm:1177` | `alloc_image` runs `zfs create` for a zvol that now exists, giving **error line 2** |

One synchronous stack, no race, fully deterministic. The `-o cachefile=none` at `ZFSPoolPlugin.pm:637` is what made it self-perpetuating: absent from the cache means PVE falls back, and falling back re-stamps the property. `zpool history fastpool` shows a clean `zpool create` followed by 14 such fallback imports and no `zpool set` ever, so this has been broken since the pool was created in February.

## Fix

Declare `cachefile` so `zfs-import-cache.service` imports the pool before `pve-guests.service`, via a hard ordering chain (`zfs-mount.service` -> `local-fs.target` -> `sysinit.target` -> `basic.target`). On the failing boot the margin was ~5 s.

With the pool imported, `volume_size_info` returns `4194304`, so the `!defined($size)` branch is never entered and neither error is reachable. Nothing on the VM needed fixing: all three zvols were always present and correct, which is why manual starts always worked.

**This is stable once applied.** The loop only runs in the broken direction: `activate_storage` probes `zpool list` before falling back, so with the pool already imported the `-o cachefile=none` path is never reached again. Post-fix steady state is `fastpool cachefile - default`, identical to `tank`.

Already applied on the host:

```
zpool set cachefile=/etc/zfs/zpool.cache fastpool
zpool set cachefile=/etc/zfs/zpool.cache tank
```

Verified: all three pools now in `zdb -C -U /etc/zfs/zpool.cache`, and `fastpool` reads `cachefile - default`.

`tank` is declared too. It is in the cache today only by default, so this states the invariant instead of inheriting it.

## Also: dropping `up_delay = 15`

Added for this bug, but it could never have helped. `up` is the delay before the **next** guest starts (`JSONSchema.pm:903`), not the one it is set on, and VM 200 is the only guest. `Nodes.pm:2156` sleeps unconditionally, so it was costing 12 s of boot time for nothing. Removing it returns the delay to the qemu default of 3 s, not 0.

Note this block was never committed, it existed only in the working tree, so the diff shows it as an addition.

## Rejected alternatives

- **A Terraform `pre-start` hookscript.** The attractive option (pure Terraform, per-VM, no host state), but dead: `exec_hookscript` fires at `QemuServer.pm:5566`, **25 lines after** the cloud-init regeneration that dies at `:5541`.
- **`systemctl enable zfs-import@fastpool.service`.** Would undo this fix every boot: it is `Before=zfs-import-cache.service` and its `ExecStart` uses `-o cachefile=none`.
- **`After=zfs.target` drop-in on `pve-guests.service`.** Useless, `zfs.target` is reached without the pool if it is not in the cachefile.
- **A PVE HA resource for restart-on-failure.** The LRM arms a self-fence watchdog whose worst case is a host hard reset, and `Makefile:59` disables HA deliberately.
- **Moving the cloud-init drive to `local-zfs`.** Would make the failure structurally unreachable, but redundant now that the fix is stable, and it costs a stop plus `ide2` delete plus restart of the live worker.
- **A Prometheus alert.** Homelab, not on call. The fix is meant to just work rather than page anyone.

Terraform is not used for the pool property because bpg/proxmox has no ZFS pool resource at any version (`proxmox_storage_zfspool` registers a PVE storage, it does not import a pool), and `terraform_data` + `remote-exec` runs on create only, not on drift, which is exactly this bug's regression vector.

## Validation

No reboot needed to land this. After the next natural reboot:

```
zpool history fastpool | tail                    # must gain NO new 'import -o cachefile=none'
systemd-analyze critical-chain pve-guests.service
```

The second should show `fastpool.mount` at ~3 s under `local-fs.target`. Today it shows it at 8.9 s under a target reached at 3.0 s, which is the fallback-import signature.

Full writeup in `todos/fastpool-boot-import-fix.md` (not in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)