### PR TITLE
fix(files): restore basic auth on files.dixneuf19.fr

### DIFF
--- a/gitops/argocd/apps/values.yaml
+++ b/gitops/argocd/apps/values.yaml
@@ -181,6 +181,11 @@ applications:
         jqPathExpressions:
           - ".spec.template.spec.hostUsers"
 
+  - name: files
+    namespace: netflix
+    path: gitops/netflix/files
+    type: directory
+
   # =============================================================================
   # SoundHoard (music pipeline)
   # =============================================================================

--- a/gitops/netflix/files/Makefile
+++ b/gitops/netflix/files/Makefile
@@ -2,4 +2,4 @@ NAMESPACE=netflix
 
 deploy:
 	kubectl create namespace "${NAMESPACE}" || echo "Namespace ${NAMESPACE} already exists"
-	kubectl apply -n "${NAMESPACE}" -f files.yaml
+	kubectl apply -n "${NAMESPACE}" -f .

--- a/gitops/netflix/files/external-secret.yaml
+++ b/gitops/netflix/files/external-secret.yaml
@@ -13,7 +13,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        auth: "{{ .username }}:{{ .password | bcrypt }}"
+        users: "{{ .username }}:{{ .password | bcrypt }}"
   data:
     - secretKey: username
       remoteRef:

--- a/gitops/netflix/files/files.yaml
+++ b/gitops/netflix/files/files.yaml
@@ -46,7 +46,7 @@ metadata:
   name: files
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    traefik.ingress.kubernetes.io/router.middlewares: default-files-auth@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: netflix-files-auth@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:

--- a/gitops/netflix/files/middleware.yaml
+++ b/gitops/netflix/files/middleware.yaml
@@ -1,0 +1,8 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: files-auth
+  namespace: netflix
+spec:
+  basicAuth:
+    secret: files-auth


### PR DESCRIPTION
## Problem

`files.dixneuf19.fr` serves the whole media library with **no authentication at all**, and has since the ingress-nginx to Traefik migration.

The live Ingress `netflix/files` had its `ingressClassName` flipped to `traefik` but kept its nginx annotations:

```yaml
annotations:
  nginx.ingress.kubernetes.io/auth-type: basic       # Traefik ignores these
  nginx.ingress.kubernetes.io/auth-secret: files-auth
spec:
  ingressClassName: traefik
```

Traefik doesn't understand nginx annotations, so the router ends up with no middleware. `curl https://files.dixneuf19.fr/` returns `200` and the full miniserve listing. Since the container runs with `--enable-tar` over the `media-nfs` PVC, the entire library is browsable and downloadable as tarballs by anyone.

## Why the fix in 7eed639 never landed

`files` was missing from `gitops/argocd/apps/values.yaml`, so `gitops/netflix/files/` was only ever applied by hand via its Makefile. The Traefik annotation added by the migration commit sat in git for months while the cluster kept the nginx one.

## Three further bugs that would have kept it broken

Applying the pre-PR manifest as-is would still not have enforced auth:

1. The annotation pointed at `default-files-auth@kubernetescrd`, a Middleware in the `default` namespace. No such Middleware exists anywhere; the cluster only has `traefik/basic-auth`, `traefik/body-size-50m` and `lms-yoshi/yoshi-basic-auth`. There was no Middleware manifest for files in the repo at all.
2. `external-secret.yaml` templated the htpasswd line under key `auth`. Traefik's `basicAuth` reads `users` (it tolerates any single-key secret, which is why `lms-yoshi/yoshi-basic-auth` works, but relying on that is fragile).
3. The ExternalSecret was never applied: `kubectl get externalsecret -n netflix` is empty. The live `files-auth` secret is a manual one from 2025-02-15.

## Changes

- Add `gitops/netflix/files/middleware.yaml` with the `files-auth` Traefik Middleware in the `netflix` namespace.
- Point the Ingress at `netflix-files-auth@kubernetescrd`.
- Rename the ExternalSecret target key `auth` -> `users`, matching `traefik/basic-auth`.
- Register `files` in `gitops/argocd/apps/values.yaml` so ArgoCD owns it and it can't drift again. The sync also strips the stale nginx annotations, which are present in the Ingress `last-applied-configuration`.
- Make the fallback Makefile apply the whole directory, not just `files.yaml`.

The Bitwarden secrets `files-auth-username` / `files-auth-password` already exist, so ESO has everything it needs.

## One manual step after merge

The pre-existing manual secret must be deleted once so ESO can take ownership (`creationPolicy: Owner` refuses to adopt a secret it doesn't own):

```bash
kubectl delete secret -n netflix files-auth
```

Auth is currently absent anyway, so this doesn't make the window any worse.

## Validation

```
$ helm template argocd-apps gitops/argocd/apps/     # files Application renders
$ kubectl apply -n netflix -f . --dry-run=server
externalsecret.external-secrets.io/files-auth created (server dry run)
deployment.apps/files unchanged (server dry run)
service/files unchanged (server dry run)
ingress.networking.k8s.io/files configured (server dry run)
middleware.traefik.io/files-auth created (server dry run)
```

## Related findings, not fixed here

An audit of all 24 live ingresses turned up three more stale-nginx-annotation cases:

- **`soundhoard/navidrome`**: a `configuration-snippet` denying `/metrics` is ignored by Traefik, so `https://navidrome.dixneuf19.fr/metrics` returns `200` and leaks library stats. Same class of bug, needs its own fix.
- **`default/personal-website-ingress{,-redirect}`**: still `ingressClassName: nginx`, so Traefik never picks them up and `www.dixneuf19.fr` / `dixneuf19.fr` fail TLS entirely. Manifests live in `dixneuf19/personal-website`, out of scope for this repo.
- **`immich/immich-server`** (`proxy-body-size: 0`) and **`cluedo-vitry/cluedo-vitry`** (`force-ssl-redirect: true`): cosmetic only. Traefik has no default body limit, and the HTTP to HTTPS redirect is already global on the `web` entrypoint.

Auth is confirmed working on `radioyoshi`, `grafana` and `whoami` (all 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)