### PR TITLE
chore(immich): drop the inert nginx proxy-body-size annotation

### DIFF
--- a/gitops/immich/immich/values.yaml
+++ b/gitops/immich/immich/values.yaml
@@ -50,6 +50,9 @@ immich:
         className: traefik
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
+          # Upstream chart defaults this to "0" to lift the upload limit on ingress-nginx.
+          # Traefik enforces no body limit, so drop it; restore if the controller changes.
+          nginx.ingress.kubernetes.io/proxy-body-size: null
         hosts:
           - host: immich.dixneuf19.fr
             paths:


### PR DESCRIPTION
Closes out the ingress audit that started with #1663. This was the last remaining `nginx.ingress.kubernetes.io/*` annotation in the cluster.

## It wasn't drift

I assumed this one was leftover cluster drift like the others. It isn't. The upstream immich chart ships it as a default:

```yaml
# immich-0.11.1/values.yaml:80
# proxy-body-size is set to 0 to remove the body limit on file uploads
nginx.ingress.kubernetes.io/proxy-body-size: "0"
```

So it was in the desired state all along, which is why ArgoCD kept reconciling it back. Overriding it to `null` removes the key from the merged map rather than setting it to an empty value.

## Nothing changes functionally

Traefik enforces no request body limit of its own, so the annotation has been inert since the migration. Large Immich uploads were never affected by it, and won't be affected by its removal.

The two-line comment is there so the next reader doesn't take the absence of any body-size setting as an oversight, and knows the upstream default exists and would need an equivalent if the ingress controller ever changes again.

## Validation

`helm template` diff before and after, the removed annotation is the only change in the entire rendered output:

```diff
496d495
<     nginx.ingress.kubernetes.io/proxy-body-size: "0"
```

Rendered annotations on the Ingress are now just:

```yaml
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt
```

## Audit status

With this merged, no `nginx.ingress.kubernetes.io/*` annotation remains on any of the cluster's ingresses. The two live actions from #1664 are also done: readeck is fully removed (PV left `Released` with `Retain`, data intact on the NFS server) and the cluedo-vitry ingress has been applied, with HTTP still redirecting to HTTPS via the global entrypoint redirection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)