### PR TITLE
fix(spliit): pin replicas to arm64 to stop cross-arch chunk 404s

### DIFF
--- a/gitops/spliit/spliit/templates/manifests.yaml
+++ b/gitops/spliit/spliit/templates/manifests.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: spliit
     spec:
+      # Multi-arch image: each arch is a separate next build, so replicas on
+      # different arches serve mutually incompatible JS chunk hashes.
+      nodeSelector:
+        kubernetes.io/arch: arm64
       containers:
         - name: spliit
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}


### PR DESCRIPTION
## Symptom

Spliit (tricount) loaded its UI fine, but the expense list spun forever. Pods were `Running` and `Ready`, Postgres was healthy, and nothing appeared in the server logs. A pod rollout appeared to fix it, twice, then it came back.

## Root cause

The cluster is mixed-arch: 4 arm64 Pis plus `k8s-worker-1` on amd64. `ghcr.io/spliit-app/spliit` is a multi-arch image, and its amd64 and arm64 variants are produced by separate `next build` runs. Each build gets its own Next.js `BUILD_ID` and its own Turbopack chunk filenames.

With `replicas: 2` scheduled across both architectures, the pods served mutually exclusive chunk sets:

| Pod | Node | Arch | BUILD_ID |
|---|---|---|---|
| `spliit-754474fcdd-twsv5` | k8s-worker-1 | amd64 | `_sdtKNdsLdf7RcOXtWzIC` |
| `spliit-754474fcdd-z6gw4` | brassberry-25 | arm64 | `imlWJuVAT4G0RYS25uakw` |

```
twsv5:  07m_ww04dhu02.js -> 404      3srzqai93-ohp.js -> 200
z6gw4:  07m_ww04dhu02.js -> 200      3srzqai93-ohp.js -> 404
```

Both pods report the same `imageID` (`sha256:b64a96f8...`) because kubelet reports the manifest list digest, not the per-arch one. That is why this was invisible until comparing `.next/BUILD_ID` on disk.

Traefik round-robins the HTML request and the subsequent chunk requests independently, so roughly half of all cold page loads fetched a chunk from the pod that did not build it, got a 404, and failed to hydrate. Spliit's `expense-list.tsx` renders `<ExpensesLoading />` whenever the query has no data and has no error branch, so a chunk 404 surfaces as a permanent skeleton rather than an error.

Immutable caching on `/_next/static` masked it: after a few reloads a browser holds both chunk sets and everything works. That is why a rollout looked like a fix, and why it only reproduced reliably on refresh with cache purge (~50% failure, matching the 2-replica split).

## Fix

Pin the deployment to a single architecture. arm64 leaves 3 schedulable nodes (brassberry-25/26/27) for 2 replicas; amd64 would leave only 1.

## Verification

- `helm template` renders the `nodeSelector` correctly
- Each pod individually serves the expenses page and the `groups.expenses.list` tRPC endpoint in ~100ms, so no application change is needed

## Follow-ups (not in this PR)

- Upstream: spliit's Dockerfile should build `.next` once with `--platform=$BUILDPLATFORM` so all arches ship identical chunk hashes
- Upstream: `expense-list.tsx` should handle the query error state instead of falling through to an infinite skeleton
- This repo: the app PDB is named `spliit`, colliding with the CNPG cluster of the same name (`enablePDB: false`), so CNPG keeps deleting it and ArgoCD keeps recreating it
- This repo: the arm64 pod sits at 250Mi of its 256Mi limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)