### PR TITLE
fix(spliit): rename app PDB to end the CNPG delete loop

### DIFF
--- a/gitops/spliit/spliit/templates/manifests.yaml
+++ b/gitops/spliit/spliit/templates/manifests.yaml
@@ -116,7 +116,9 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: spliit
+  # Not "spliit": the CNPG Cluster of that name owns the PDB names it derives
+  # from itself, and deletes this one on every reconcile (enablePDB: false).
+  name: spliit-web
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
## Problem

The Deployment's `PodDisruptionBudget` is named `spliit`, which is also the name of the CNPG `Cluster` in the same namespace. CNPG derives its PDB names from the cluster name, and this cluster sets `enablePDB: false` (it is single-instance, so a PDB would block node upgrades).

So CNPG deletes the PDB named `spliit` on every reconcile, and ArgoCD self-heal recreates it. Neither side ever wins.

## Evidence

The loop has run 52 times:

```
$ kubectl get events -n spliit --field-selector reason=DeletingPodDisruptionBudget
TIME                   COUNT   OBJ      MSG
2026-08-14T20:00:41Z   52      spliit   Deleting Pod Disruption Budget spliit
```

The PDB that CNPG is deleting is ours, not one of its own:

- no `ownerReferences` and no CNPG labels
- selector `app: spliit`, `expected=2 healthy=2`, matching the two application pods
- `creationTimestamp: 2026-08-14T20:00:42Z`, exactly one second after the delete event above

## Fix

Rename to `spliit-web`. Same selector, same `maxUnavailable: 1`, no behaviour change. It just stops colliding with the name CNPG claims.

Found while investigating the expense list hang (#1666), though it is an independent issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)