### PR TITLE
feat(scaleway): provision CNPG backup bucket and scoped credentials

### DIFF
--- a/bitwarden/terraform/remote_state.tf
+++ b/bitwarden/terraform/remote_state.tf
@@ -1,0 +1,20 @@
+data "terraform_remote_state" "scaleway" {
+  backend = "s3"
+
+  config = {
+    bucket = "dixneuf19-tfstates"
+    key    = "scaleway/terraform.tfstate"
+    region = "fr-par"
+
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+
+    # Required for S3-compatible backends (non-AWS)
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_s3_checksum            = true
+  }
+}

--- a/bitwarden/terraform/secrets.tf
+++ b/bitwarden/terraform/secrets.tf
@@ -9,6 +9,25 @@ resource "bitwarden-secrets_secret" "navidrome_password_encryption_key" {
   special = false
 }
 
+# ── Secrets sourced from another Terraform root ───────────────────────────────
+# Apply scaleway/terraform first, these read its outputs from the remote state.
+
+resource "bitwarden-secrets_secret" "cnpg_backup_access_key_id" {
+  key        = "cnpg-backup-access-key-id"
+  project_id = var.bw_project_id
+  note       = "Scaleway API key ID for CloudNativePG backups"
+
+  value = data.terraform_remote_state.scaleway.outputs.cnpg_backup_access_key_id
+}
+
+resource "bitwarden-secrets_secret" "cnpg_backup_secret_access_key" {
+  key        = "cnpg-backup-secret-access-key"
+  project_id = var.bw_project_id
+  note       = "Scaleway API secret key for CloudNativePG backups"
+
+  value = data.terraform_remote_state.scaleway.outputs.cnpg_backup_secret_access_key
+}
+
 # ── Imported secrets ─────────────────────────────────────────────────────────
 # These already exist in Bitwarden. Terraform adopts them without recreating.
 #

--- a/scaleway/terraform/cnpg_backups.tf
+++ b/scaleway/terraform/cnpg_backups.tf
@@ -1,0 +1,58 @@
+# Object Storage permission sets are project-scoped, never bucket-scoped, so the
+# backup credentials live in their own project to keep them away from dixneuf19-tfstates.
+resource "scaleway_account_project" "cnpg_backups" {
+  name        = "cnpg-backups"
+  description = "CloudNativePG backup storage"
+}
+
+resource "scaleway_object_bucket" "cnpg_backups" {
+  name       = "dixneuf19-cnpg-backups"
+  region     = "fr-par"
+  project_id = scaleway_account_project.cnpg_backups.id
+
+  # Only logical dumps are lifecycled. Barman handles retention under physical/.
+  lifecycle_rule {
+    id      = "logical-dumps"
+    prefix  = "logical/"
+    enabled = true
+
+    transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+
+resource "scaleway_iam_application" "cnpg_backups" {
+  name        = "cnpg-backups"
+  description = "CloudNativePG backups to dixneuf19-cnpg-backups"
+}
+
+resource "scaleway_iam_policy" "cnpg_backups" {
+  name           = "cnpg-backups"
+  description    = "Object Storage access limited to the cnpg-backups project"
+  application_id = scaleway_iam_application.cnpg_backups.id
+
+  rule {
+    project_ids = [scaleway_account_project.cnpg_backups.id]
+
+    permission_set_names = [
+      "ObjectStorageBucketsRead",
+      "ObjectStorageObjectsRead",
+      "ObjectStorageObjectsWrite",
+      "ObjectStorageObjectsDelete",
+    ]
+  }
+}
+
+resource "scaleway_iam_api_key" "cnpg_backups" {
+  application_id = scaleway_iam_application.cnpg_backups.id
+  description    = "CloudNativePG backups"
+
+  # S3 clients cannot pass a project ID, the key's default project is used instead.
+  default_project_id = scaleway_account_project.cnpg_backups.id
+}

--- a/scaleway/terraform/outputs.tf
+++ b/scaleway/terraform/outputs.tf
@@ -1,0 +1,11 @@
+output "cnpg_backup_access_key_id" {
+  description = "Scaleway API key ID for CloudNativePG backups"
+  value       = scaleway_iam_api_key.cnpg_backups.access_key
+  sensitive   = true
+}
+
+output "cnpg_backup_secret_access_key" {
+  description = "Scaleway API secret key for CloudNativePG backups"
+  value       = scaleway_iam_api_key.cnpg_backups.secret_key
+  sensitive   = true
+}


### PR DESCRIPTION
Infra side of the CloudNativePG backup setup. The Kubernetes wiring (ObjectStore / ScheduledBackup, ExternalSecret) comes in a follow-up PR.

## What this adds

`scaleway/terraform/`:
- `dixneuf19-cnpg-backups` bucket in fr-par, versioning off. WAL churn plus Barman retention deletions would only accumulate noncurrent versions.
- Lifecycle rule scoped to the `logical/` prefix: GLACIER after 30 days, expiry after 365 days.
- A dedicated `cnpg-backups` IAM application, policy and API key, plus both credentials as sensitive outputs.

`bitwarden/terraform/`:
- `cnpg-backup-access-key-id` and `cnpg-backup-secret-access-key`, read from the scaleway root via `terraform_remote_state` on the same S3 backend. No manual copy-paste.

## Bucket layout

One bucket serves both backup kinds:
- `physical/<namespace>/<cluster>` for base backups and WAL, retention managed by Barman, no lifecycle rule.
- `logical/<namespace>/<cluster>` for future logical dumps, retention managed by the lifecycle rule above.

## Why a separate Scaleway project instead of a bucket policy

Every `ObjectStorage*` permission set is project-scoped (`scw iam permission-set list` confirms: `scope_type: projects`), so IAM cannot restrict an application to a single bucket. A bucket policy on `dixneuf19-cnpg-backups` would not have solved it either: on Scaleway the effective rights are the intersection of IAM and bucket policy, and a bucket with no policy is governed by IAM alone. The application would still have had object read and write on `dixneuf19-tfstates`. Locking that down would have meant putting a bucket policy on the state bucket itself, which risks losing access to the Terraform backend.

So the bucket and its credentials live in a new `cnpg-backups` project, and the IAM policy rule is scoped to that project only (`ObjectStorageBucketsRead`, `ObjectStorageObjectsRead`, `ObjectStorageObjectsWrite`, `ObjectStorageObjectsDelete`). The API key sets `default_project_id` to it, since S3 clients cannot pass a project ID. Nothing in the existing `homelab` project is touched.

Creating the project needs `ProjectManager` at organization level, which the owner key has.

## Apply order

Nothing is applied, you apply manually:

1. `cd scaleway/terraform && terraform plan` then apply
2. `cd bitwarden/terraform && terraform plan` then apply, it reads the outputs of step 1

## Validation

`terraform fmt` is clean on both roots. `terraform validate` passes on both, run against copies with the version pin relaxed because the local binary is 1.15.5 while the roots pin 1.15.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)