### PR TITLE
feat(cnpg): physical backups and WAL archival via barman cloud plugin

### DIFF
--- a/gitops/cnpg-system/cloudnative-pg/Chart.lock
+++ b/gitops/cnpg-system/cloudnative-pg/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: cloudnative-pg
   repository: https://cloudnative-pg.github.io/charts
   version: 0.29.0
-digest: sha256:211fb7c6f0a62adc8315aef78befc5cb4a13f6c33cfed15f32f8490a48c1e0b2
-generated: "2026-07-30T17:06:31.931470256Z"
+- name: plugin-barman-cloud
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.7.1
+digest: sha256:e10e91c879895d7d3e885265a1ea1dc85974b84436c7cc2146279638a6935f84
+generated: "2026-08-14T23:16:04.644666+02:00"

--- a/gitops/cnpg-system/cloudnative-pg/Chart.yaml
+++ b/gitops/cnpg-system/cloudnative-pg/Chart.yaml
@@ -11,3 +11,6 @@ dependencies:
   - name: cloudnative-pg
     version: 0.29.0
     repository: https://cloudnative-pg.github.io/charts
+  - name: plugin-barman-cloud
+    version: 0.7.1
+    repository: https://cloudnative-pg.github.io/charts

--- a/gitops/cnpg-system/cloudnative-pg/values.yaml
+++ b/gitops/cnpg-system/cloudnative-pg/values.yaml
@@ -24,3 +24,11 @@ cloudnative-pg:
       labels: {}
       # -- Annotations that ConfigMaps can have to get configured in Grafana.
       annotations: {}
+
+plugin-barman-cloud:
+  resources:
+    limits:
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi

--- a/gitops/immich/immich/templates/external-secret-backup.yaml
+++ b/gitops/immich/immich/templates/external-secret-backup.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: immich-backup-s3
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: immich-backup-s3
+  data:
+    - secretKey: ACCESS_KEY_ID
+      remoteRef:
+        key: cnpg-backup-access-key-id
+    - secretKey: ACCESS_SECRET_KEY
+      remoteRef:
+        key: cnpg-backup-secret-access-key

--- a/gitops/immich/immich/templates/objectstore.yaml
+++ b/gitops/immich/immich/templates/objectstore.yaml
@@ -1,0 +1,28 @@
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: immich-backup
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://dixneuf19-cnpg-backups/physical/{{ .Release.Namespace }}
+    endpointURL: https://s3.fr-par.scw.cloud
+    s3Credentials:
+      accessKeyId:
+        name: immich-backup-s3
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: immich-backup-s3
+        key: ACCESS_SECRET_KEY
+    wal:
+      compression: zstd
+  instanceSidecarConfiguration:
+    env:
+      # s3Credentials.region does not reach boto3 (cloudnative-pg#9724), and
+      # Scaleway rejects signatures scoped to the default us-east-1
+      - name: AWS_DEFAULT_REGION
+        value: fr-par
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required

--- a/gitops/immich/immich/templates/postgres-cluster.yaml
+++ b/gitops/immich/immich/templates/postgres-cluster.yaml
@@ -9,6 +9,11 @@ spec:
   storage:
     storageClass: local-path
     size: 20Gi
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: immich-backup
   postgresql:
     shared_preload_libraries:
       - "vchord.so"

--- a/gitops/immich/immich/templates/scheduled-backup.yaml
+++ b/gitops/immich/immich/templates/scheduled-backup.yaml
@@ -3,7 +3,7 @@ kind: ScheduledBackup
 metadata:
   name: immich-weekly
 spec:
-  schedule: "0 0 3 * * 0"
+  schedule: "0 19 3 * * 0"
   immediate: true
   backupOwnerReference: self
   cluster:

--- a/gitops/immich/immich/templates/scheduled-backup.yaml
+++ b/gitops/immich/immich/templates/scheduled-backup.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: immich-weekly
+spec:
+  schedule: "0 0 3 * * 0"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: immich
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/gitops/spliit/spliit/templates/external-secret-backup.yaml
+++ b/gitops/spliit/spliit/templates/external-secret-backup.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: spliit-backup-s3
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: spliit-backup-s3
+  data:
+    - secretKey: ACCESS_KEY_ID
+      remoteRef:
+        key: cnpg-backup-access-key-id
+    - secretKey: ACCESS_SECRET_KEY
+      remoteRef:
+        key: cnpg-backup-secret-access-key

--- a/gitops/spliit/spliit/templates/objectstore.yaml
+++ b/gitops/spliit/spliit/templates/objectstore.yaml
@@ -1,0 +1,28 @@
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: spliit-backup
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://dixneuf19-cnpg-backups/physical/{{ .Release.Namespace }}
+    endpointURL: https://s3.fr-par.scw.cloud
+    s3Credentials:
+      accessKeyId:
+        name: spliit-backup-s3
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: spliit-backup-s3
+        key: ACCESS_SECRET_KEY
+    wal:
+      compression: zstd
+  instanceSidecarConfiguration:
+    env:
+      # s3Credentials.region does not reach boto3 (cloudnative-pg#9724), and
+      # Scaleway rejects signatures scoped to the default us-east-1
+      - name: AWS_DEFAULT_REGION
+        value: fr-par
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required

--- a/gitops/spliit/spliit/templates/postgres-cluster.yaml
+++ b/gitops/spliit/spliit/templates/postgres-cluster.yaml
@@ -10,6 +10,11 @@ spec:
     kind: ClusterImageCatalog
     name: postgresql-minimal-trixie
     major: 18
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: spliit-backup
   storage:
     size: 10Gi
   resources:

--- a/gitops/spliit/spliit/templates/scheduled-backup.yaml
+++ b/gitops/spliit/spliit/templates/scheduled-backup.yaml
@@ -3,7 +3,7 @@ kind: ScheduledBackup
 metadata:
   name: spliit-weekly
 spec:
-  schedule: "0 0 4 * * 0"
+  schedule: "0 19 4 * * 0"
   immediate: true
   backupOwnerReference: self
   cluster:

--- a/gitops/spliit/spliit/templates/scheduled-backup.yaml
+++ b/gitops/spliit/spliit/templates/scheduled-backup.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: spliit-weekly
+spec:
+  schedule: "0 0 4 * * 0"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: spliit
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io


### PR DESCRIPTION
Enables physical backups plus continuous WAL archival for both CNPG clusters, using the official Barman Cloud CNPG-I plugin, with objects stored in the Scaleway bucket `dixneuf19-cnpg-backups` (fr-par).

## What changed

- `gitops/cnpg-system/cloudnative-pg`: added `plugin-barman-cloud` 0.7.1 (plugin v0.14.0) as a second chart dependency, so the plugin deployment lands in `cnpg-system` beside the operator, which the plugin requires. cert-manager is already installed, so its issuer and certificates resolve. Chart.lock refreshed.
- `immich` and `spliit` charts each gained:
  - an `ExternalSecret` (`<app>-backup-s3`) exposing `ACCESS_KEY_ID` and `ACCESS_SECRET_KEY` from the Bitwarden keys `cnpg-backup-access-key-id` and `cnpg-backup-secret-access-key`
  - an `ObjectStore` (`<app>-backup`) with zstd WAL compression and a 30d retention policy
  - a `plugins:` block on the `Cluster` with `isWALArchiver: true`
  - a weekly `ScheduledBackup` (`immediate: true`, `backupOwnerReference: self`), immich Sunday 03:00 and spliit Sunday 04:00

No new ArgoCD Application entries: the plugin rides the existing `cloudnative-pg` app and the per-app manifests ride their own app charts.

## Merge order

The sibling Terraform PR on `feat/cnpg-backup-bucket` creates the bucket and the Bitwarden secrets, and must be applied first, otherwise the two ExternalSecrets will not sync and the ObjectStores stay credential-less. Merging this PR before that is otherwise safe: the clusters keep running, only backups fail.

## Rolling restart

Adding the `plugins:` block to a Cluster injects the barman sidecar into the instance pods, which triggers a rolling restart of each cluster. Both run `instances: 1`, so immich and spliit each take a brief outage while the single pod is recreated.

## Path layout

Objects land under `s3://dixneuf19-cnpg-backups/physical/<namespace>/<serverName>/`, so `physical/immich/immich` and `physical/spliit/spliit`. `serverName` defaults to the cluster name and is deliberately left unset in the ObjectStore. On a restore, the recovered cluster must archive under a fresh `serverName` (for example `immich-v2`) so it does not overwrite the WAL history of the source it was recovered from.

## Scaleway specifics

`AWS_DEFAULT_REGION=fr-par` is set through `instanceSidecarConfiguration.env` because the declarative `s3Credentials.region` field does not propagate to boto3 (cloudnative-pg/cloudnative-pg#9724) and Scaleway rejects requests signed for the default `us-east-1`. The two checksum variables are set to `when_required` for the same S3-compatibility reason.

## Validation

Nothing was applied to the cluster. Locally:

- `helm template` renders cleanly for the `cloudnative-pg`, `immich`, and `spliit` charts (spliit needs `--set image.tag=...` locally, since the tag is supplied by Image Updater, a pre-existing quirk)
- every new `ObjectStore`, `ScheduledBackup`, and modified `Cluster` was validated against the OpenAPI schemas of the CRDs shipped by the charts
- the CI ArgoCD diff comment on this PR will preview the live changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)