### PR TITLE
fix(scaleway): cnpg backup bucket apply fixes and provider warning cleanup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,13 +6,11 @@ export SSH_KNOWN_HOSTS=/dev/null
 
 export BIN_DIR="$HOME/.rd/bin"
 
-# Scaleway credentials (still needed for TF S3 backend)
-export SCW_ACCESS_KEY=$(scw config get access-key)
-export SCW_SECRET_KEY=$(scw config get secret-key)
-export SCW_DEFAULT_PROJECT_ID=$(scw config get default-project-id)
-export SCW_DEFAULT_ORGANIZATION_ID=$(scw config get default-organization-id)
-export AWS_ACCESS_KEY_ID=$SCW_ACCESS_KEY
-export AWS_SECRET_ACCESS_KEY=$SCW_SECRET_KEY
+# Scaleway credentials for the TF S3 state backend. The scaleway provider itself
+# reads the scw CLI profile directly, do not export SCW_* here (duplicate sources
+# trigger provider warnings).
+export AWS_ACCESS_KEY_ID=$(scw config get access-key)
+export AWS_SECRET_ACCESS_KEY=$(scw config get secret-key)
 
 # Helper: read a secret by name from Bitwarden Secrets Manager (cached)
 _BWS_CACHE=$(bws secret list --output json 2>/dev/null)

--- a/scaleway/terraform/cnpg_backups.tf
+++ b/scaleway/terraform/cnpg_backups.tf
@@ -17,7 +17,8 @@ resource "scaleway_object_bucket" "cnpg_backups" {
     enabled = true
 
     transition {
-      days          = 30
+      # Scaleway minimum for GLACIER transitions
+      days          = 90
       storage_class = "GLACIER"
     }
 
@@ -55,4 +56,8 @@ resource "scaleway_iam_api_key" "cnpg_backups" {
 
   # S3 clients cannot pass a project ID, the key's default project is used instead.
   default_project_id = scaleway_account_project.cnpg_backups.id
+
+  # Org policy mandates an expiry. WAL archiving breaks silently past this date,
+  # rotate by bumping it and re-running both TF roots.
+  expires_at = "2030-01-01T00:00:00Z"
 }

--- a/scaleway/terraform/provider.tf
+++ b/scaleway/terraform/provider.tf
@@ -1,7 +1,3 @@
-# Scaleway provider reads credentials from environment variables:
-#   SCW_ACCESS_KEY, SCW_SECRET_KEY, SCW_DEFAULT_PROJECT_ID, SCW_DEFAULT_ORGANIZATION_ID
-# These are set by direnv via `scw config get`.
-provider "scaleway" {
-  region = "fr-par"
-  zone   = "fr-par-1"
-}
+# Credentials, project, region and zone all come from the active scw CLI profile
+# (~/.config/scw/config.yaml), the single source so the provider stays quiet.
+provider "scaleway" {}


### PR DESCRIPTION
Follow-ups to #1668 that were pushed after it merged (commits recovered from the stale branch).

- Glacier transition on the logical/ prefix moved from 30 to 90 days, the Scaleway API minimum. The apply failed on this.
- expires_at added to the cnpg-backups API key, required by org security settings. Set to 2030-01-01; WAL archiving breaks silently past that date, rotate by bumping it and re-applying both roots.
- Provider warning cleanup: the scaleway provider now reads everything from the active scw CLI profile. .envrc keeps only the AWS_* aliases for the S3 state backend, and the provider block no longer duplicates region and zone. After pulling, run direnv allow.

Re-apply scaleway/terraform after merging. If the bucket was left out of state by the failed apply, import it first:
terraform import scaleway_object_bucket.cnpg_backups fr-par/dixneuf19-cnpg-backups

🤖 Generated with [Claude Code](https://claude.com/claude-code)