### PR TITLE
fix(karakeep): rename meilisearch dumpless upgrade flag to MEILI_UPGRADE_DB

### DIFF
--- a/gitops/karakeep/karakeep/values.yaml
+++ b/gitops/karakeep/karakeep/values.yaml
@@ -139,7 +139,7 @@ meilisearch:
   environment:
     MEILI_ENV: production
     MEILI_NO_ANALYTICS: true
-    MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE: true # Otherwise every minor upgrade requires a full dump/restore
+    MEILI_UPGRADE_DB: true # Otherwise every engine upgrade requires a full dump/restore (renamed from MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE in v1.51)
   persistence:
     enabled: true
     size: 1Gi

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>dixneuf19/renovate-presets"]
+  "extends": ["local>dixneuf19/renovate-presets"],
+  "packageRules": [
+    {
+      "description": "Meilisearch chart minors bundle engine upgrades that may need DB migration steps",
+      "matchPackageNames": ["meilisearch"],
+      "automerge": false
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>dixneuf19/renovate-presets"],
-  "packageRules": [
-    {
-      "description": "Meilisearch chart minors bundle engine upgrades that may need DB migration steps",
-      "matchPackageNames": ["meilisearch"],
-      "automerge": false
-    }
-  ]
+  "extends": ["local>dixneuf19/renovate-presets"]
 }


### PR DESCRIPTION
## Why meilisearch is down

- The meilisearch DB on disk is at 1.42.1 (chart 0.32.0, the last working deploy).
- Renovate auto-merged chart 0.35.0 (#1654, engine v1.51.0) and 0.36.0 (#1660, engine v1.52.0).
- Meilisearch v1.51.0 stabilized dumpless upgrade and renamed the flag: `MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE` is now `MEILI_UPGRADE_DB` ([release notes](https://github.com/meilisearch/meilisearch/releases/tag/v1.51.0)). Unknown env vars are silently ignored, so v1.51.0 started with no upgrade flag, found a 1.42.1 database, and refused to boot.
- The v1.52.0 rollout is stuck on top of that: the StatefulSet controller never replaces a pod that never became Ready (`karakeep-meilisearch-0` is at 2000+ restarts over 7 days).

## Fix

Rename the env var to `MEILI_UPGRADE_DB: true` so the engine migrates the DB in place on startup (dumpless upgrade supports any source >= v1.12).

Renovate automerge stays enabled for meilisearch: now that the flag is stable, engine minors migrate the DB automatically.

## After merge

Once ArgoCD syncs the ConfigMap, the stuck pod must be deleted manually so the StatefulSet recreates it with the new image and env:

```
kubectl delete pod -n karakeep karakeep-meilisearch-0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)