### PR TITLE
chore(karakeep): disable selfHeal for data migration window

### DIFF
--- a/gitops/argocd/apps/values.yaml
+++ b/gitops/argocd/apps/values.yaml
@@ -208,7 +208,7 @@ applications:
   - name: karakeep
     namespace: karakeep
     path: gitops/karakeep/karakeep
-    selfHeal: true
+    selfHeal: false # Temporary: data migration to local-path in progress
 
   - name: spliit
     namespace: spliit


### PR DESCRIPTION
Step 1 of moving karakeep's data from `nfs-client` to `local-path` on k8s-worker-1 (SQLite on NFS is the same corruption risk that killed Navidrome's DB; worker-1's disk sits on jonbonas fastpool ZFS).

With `selfHeal: false`, the manual migration steps (scale to 0, delete/recreate PVC, restore from backup) stick, while automated sync stays enabled (it only fires on commits touching the app path).

Plan:
1. **This PR**: suspend selfHeal.
2. **Window** (~15 min downtime): scale to 0, fresh backup, recreate `karakeep-data` PVC as `local-path`, restore data via a temp pod pinned to k8s-worker-1, repin the deployment, scale up, verify.
3. **Follow-up PR**: `storageClass: local-path` + nodeSelector `k8s-worker-1` + `Prune=false` on the PVC, revert `selfHeal: true`.

Backups already taken and verified (sha256 match): laptop + `jonbonas:/tank/data/backups/karakeep/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)