### PR TITLE
feat(karakeep): move data to local-path on k8s-worker-1

### DIFF
--- a/gitops/argocd/apps/values.yaml
+++ b/gitops/argocd/apps/values.yaml
@@ -208,7 +208,7 @@ applications:
   - name: karakeep
     namespace: karakeep
     path: gitops/karakeep/karakeep
-    selfHeal: false # Temporary: data migration to local-path in progress
+    selfHeal: true
 
   - name: spliit
     namespace: spliit

--- a/gitops/karakeep/karakeep/templates/pvc.yaml
+++ b/gitops/karakeep/karakeep/templates/pvc.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "karakeep.fullname" . }}-data
+  annotations:
+    # local-path reclaim is Delete: pruning this PVC destroys the data
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     {{- include "karakeep.labels" . | nindent 4 }}
 spec:

--- a/gitops/karakeep/karakeep/values.yaml
+++ b/gitops/karakeep/karakeep/values.yaml
@@ -57,7 +57,7 @@ resources:
     memory: 256Mi
 
 nodeSelector:
-  kubernetes.io/arch: arm64
+  kubernetes.io/hostname: k8s-worker-1
 
 tolerations: []
 
@@ -90,7 +90,7 @@ secretEnvVars:
 
 persistence:
   enabled: true
-  storageClass: "nfs-client"
+  storageClass: "local-path"
   accessMode: ReadWriteOnce
   size: 10Gi
   mountPath: "/data"


### PR DESCRIPTION
Step 3 of the karakeep storage migration (follows #1672). Aligns git with the state already applied live.

## What happened live (2026-08-15 ~00:15-00:40 CEST, ~20 min downtime)

1. Automated sync removed from `argocd-apps` + `karakeep` apps for the window (selfHeal off was not enough: any new repo commit re-triggers automated sync of an OutOfSync app, which undid the first scale-down).
2. Karakeep scaled to 0, final backup taken from the NFS server with writes stopped, verified (`PRAGMA integrity_check` ok, 1640 bookmarks) and copied to the laptop + `jonbonas:/tank/data/backups/karakeep/`.
3. `karakeep-data` PVC recreated as `local-path` (storageClass is immutable). Gotcha: the restore pod needed `nodeSelector` instead of `nodeName`, since bypassing the scheduler leaves a WaitForFirstConsumer PVC Pending forever.
4. Data restored onto k8s-worker-1 (435M, 4832 files), deployment repinned, scaled up, verified: pod Running on worker-1, public health 200, search API returns bookmarks.

## This PR

- `persistence.storageClass: local-path`, nodeSelector `kubernetes.io/hostname: k8s-worker-1` (VM disk is a zvol on jonbonas fastpool ZFS)
- `Prune=false` on the PVC: local-path reclaim is Delete, a prune would destroy the data
- Reverts the temporary `selfHeal: false` from #1672

## Rollback path

Old NFS PV `pvc-4a3ec79b-...` is Released with data retained at `brassberry-25:/mnt/tuyhoa_2T/karakeep-karakeep-data-pvc-4a3ec79b-...`, plus the two tar backups.

## Follow-ups

- Nightly backup CronJob to a `nfs-jonbonas` PVC (tank RAIDZ1)
- Same local-path move for meilisearch (fresh volume + reindex, no data migration needed)
- Delete the Released NFS PV after a soak period

🤖 Generated with [Claude Code](https://claude.com/claude-code)