### PR TITLE
feat(karakeep): nightly consistent backup to the NAS

### DIFF
--- a/gitops/karakeep/karakeep/files/backup.sh
+++ b/gitops/karakeep/karakeep/files/backup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# Consistent nightly backup of karakeep: sqlite3 .backup for the DB
+# (safe with the app running), plain tar for the write-once assets.
+
+DATA_DIR="${DATA_DIR:-/data}"
+BACKUP_DIR="${BACKUP_DIR:-/backup}"
+RETENTION_DAYS="${RETENTION_DAYS:?required}"
+
+stamp="$(date +%Y-%m-%d-%H%M)"
+work="${BACKUP_DIR}/work"
+trap 'rm -rf "${work}"' EXIT
+rm -rf "${work}" && mkdir -p "${work}"
+
+sqlite3 "${DATA_DIR}/db.db" ".backup '${work}/db.db'"
+sqlite3 "${work}/db.db" "PRAGMA integrity_check;" | grep -qx ok
+
+tar czf "${BACKUP_DIR}/karakeep-${stamp}.tar.gz" \
+  -C "${work}" db.db \
+  -C "${DATA_DIR}" assets
+
+find "${BACKUP_DIR}" -maxdepth 1 -name 'karakeep-*.tar.gz' \
+  -mtime "+${RETENTION_DAYS}" -delete
+
+echo "backup done:"
+ls -lh "${BACKUP_DIR}"

--- a/gitops/karakeep/karakeep/templates/backup-cronjob.yaml
+++ b/gitops/karakeep/karakeep/templates/backup-cronjob.yaml
@@ -15,6 +15,16 @@ spec:
       storage: {{ .Values.backup.persistence.size }}
   storageClassName: {{ .Values.backup.persistence.storageClass }}
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "karakeep.fullname" . }}-backup-script
+  labels:
+    {{- include "karakeep.labels" . | nindent 4 }}
+data:
+  backup.sh: |
+    {{- .Files.Get "files/backup.sh" | nindent 4 }}
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -48,19 +58,10 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - |
-                  set -eu
-                  apk add --no-cache sqlite tar
-                  stamp=$(date +%Y-%m-%d-%H%M)
-                  work=/backup/work
-                  rm -rf "$work" && mkdir -p "$work"
-                  sqlite3 /data/db.db ".backup '$work/db.db'"
-                  sqlite3 /data/queue.db ".backup '$work/queue.db'"
-                  sqlite3 "$work/db.db" "PRAGMA integrity_check;" | grep -qx ok
-                  tar czf "/backup/karakeep-$stamp.tar.gz" -C "$work" db.db queue.db -C /data assets
-                  rm -rf "$work"
-                  find /backup -maxdepth 1 -name 'karakeep-*.tar.gz' -mtime +{{ .Values.backup.retentionDays }} -delete
-                  echo "backup done:" && ls -lh /backup
+                - apk add --no-cache bash sqlite tar >/dev/null && exec bash /scripts/backup.sh
+              env:
+                - name: RETENTION_DAYS
+                  value: {{ .Values.backup.retentionDays | quote }}
               resources:
                 requests:
                   cpu: 50m
@@ -72,6 +73,8 @@ spec:
                   mountPath: /data
                 - name: backups
                   mountPath: /backup
+                - name: script
+                  mountPath: /scripts
           volumes:
             - name: data
               persistentVolumeClaim:
@@ -79,4 +82,7 @@ spec:
             - name: backups
               persistentVolumeClaim:
                 claimName: {{ include "karakeep.fullname" . }}-backups
+            - name: script
+              configMap:
+                name: {{ include "karakeep.fullname" . }}-backup-script
 {{- end }}

--- a/gitops/karakeep/karakeep/templates/backup-cronjob.yaml
+++ b/gitops/karakeep/karakeep/templates/backup-cronjob.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "karakeep.fullname" . }}-backups
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  labels:
+    {{- include "karakeep.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.backup.persistence.size }}
+  storageClassName: {{ .Values.backup.persistence.storageClass }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "karakeep.fullname" . }}-backup
+  labels:
+    {{- include "karakeep.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800
+      template:
+        metadata:
+          labels:
+            # Not karakeep.selectorLabels: the Service selects on those and
+            # would route traffic to this pod
+            app.kubernetes.io/name: {{ include "karakeep.name" . }}-backup
+            app.kubernetes.io/instance: {{ .Release.Name }}
+        spec:
+          restartPolicy: Never
+          # Must co-locate with the app: the data PVC is local-path RWO
+          nodeSelector:
+            {{- toYaml .Values.nodeSelector | nindent 12 }}
+          containers:
+            - name: backup
+              image: {{ .Values.backup.image }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache sqlite tar
+                  stamp=$(date +%Y-%m-%d-%H%M)
+                  work=/backup/work
+                  rm -rf "$work" && mkdir -p "$work"
+                  sqlite3 /data/db.db ".backup '$work/db.db'"
+                  sqlite3 /data/queue.db ".backup '$work/queue.db'"
+                  sqlite3 "$work/db.db" "PRAGMA integrity_check;" | grep -qx ok
+                  tar czf "/backup/karakeep-$stamp.tar.gz" -C "$work" db.db queue.db -C /data assets
+                  rm -rf "$work"
+                  find /backup -maxdepth 1 -name 'karakeep-*.tar.gz' -mtime +{{ .Values.backup.retentionDays }} -delete
+                  echo "backup done:" && ls -lh /backup
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 256Mi
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                - name: backups
+                  mountPath: /backup
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: {{ include "karakeep.fullname" . }}-data
+            - name: backups
+              persistentVolumeClaim:
+                claimName: {{ include "karakeep.fullname" . }}-backups
+{{- end }}

--- a/gitops/karakeep/karakeep/values.yaml
+++ b/gitops/karakeep/karakeep/values.yaml
@@ -124,6 +124,16 @@ readinessProbe:
   timeoutSeconds: 3
   failureThreshold: 3
 
+# Nightly consistent backup (sqlite3 .backup + assets tar) to the NAS
+backup:
+  enabled: true
+  schedule: "30 3 * * *"
+  retentionDays: 14
+  image: alpine:3.22
+  persistence:
+    storageClass: "nfs-jonbonas"
+    size: 20Gi
+
 # Autoscaling
 autoscaling:
   enabled: false


### PR DESCRIPTION
Follow-up to #1673: the promised backup layer for karakeep's now-local data.

Nightly CronJob (03:30) that:
1. Snapshots `db.db` with `sqlite3 .backup` (online backup API): a transactionally consistent copy with the app running, unlike a raw tar of a live SQLite file which can capture a torn mix of pages. `queue.db` is skipped: it's a transient job queue karakeep rebuilds after restore.
2. Runs `PRAGMA integrity_check` on the copy and fails the job if not ok
3. Tars the DB + `assets/` (write-once blobs, plain copy is fine) to a `nfs-jonbonas` PVC, physically on the tank RAIDZ1 pool at `jonbonas:/tank/data/karakeep/karakeep-backups/`
4. Prunes backups older than 14 days

The backup logic lives in `files/backup.sh` (bash strict mode), shipped via ConfigMap; retention is passed as an env var. Restore is untar-into-`/data`.

Details:
- Pinned to k8s-worker-1: the data PVC is local-path RWO, same-node mount required
- Job pod does not carry the app's selector labels (the Service would route traffic to it)
- Backups PVC gets `Prune=false` like the data PVC
- Litestream (streaming WAL replication, offsite S3) deliberately deferred; this covers the basics first

🤖 Generated with [Claude Code](https://claude.com/claude-code)