### PR TITLE
Add outside-temperature correlation dashboard (Open-Meteo + jonbonas temps)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,4 +79,8 @@ proxmox-grub-aspm:
 proxmox-nfs:
 	ansible-playbook -i $(ANSIBLE_INVENTORY) proxmox/playbooks/proxmox-nfs.yaml
 
-.PHONY: all ping reboot tailscale jellyfin mounts kernel-modules upgrade nfs-server remove-nfs-server kubeconfig k0sctl proxmox-post-install proxmox-bootstrap proxmox-zfs proxmox-grub-aspm proxmox-nfs tailscale-hostmap-pull tailscale-hosts
+# node_exporter on the Proxmox host (CPU/NVMe/HDD temperatures)
+proxmox-node-exporter:
+	ansible-playbook -i $(ANSIBLE_INVENTORY) proxmox/playbooks/proxmox-node-exporter.yaml
+
+.PHONY: all ping reboot tailscale jellyfin mounts kernel-modules upgrade nfs-server remove-nfs-server kubeconfig k0sctl proxmox-post-install proxmox-bootstrap proxmox-zfs proxmox-grub-aspm proxmox-nfs proxmox-node-exporter tailscale-hostmap-pull tailscale-hosts

--- a/gitops/argocd/apps/values.yaml
+++ b/gitops/argocd/apps/values.yaml
@@ -95,6 +95,10 @@ applications:
     namespace: monitoring
     path: gitops/monitoring/kube-state-metrics/
 
+  - name: weather-exporter
+    namespace: monitoring
+    path: gitops/monitoring/weather-exporter
+
   # =============================================================================
   # Storage
   # =============================================================================

--- a/gitops/monitoring/kps/values.yaml
+++ b/gitops/monitoring/kps/values.yaml
@@ -200,6 +200,13 @@ kube-prometheus-stack:
       podMonitorNamespaceSelector:
         matchLabels: {}
 
+      # Out-of-cluster targets (jonbonas Proxmox host, see proxmox-node-exporter playbook)
+      additionalScrapeConfigs:
+        - job_name: node-exporter-jonbonas
+          static_configs:
+            - targets:
+                - 192.168.1.30:9100
+
       retention: 30d
 
       resources:

--- a/gitops/monitoring/weather-exporter/Chart.lock
+++ b/gitops/monitoring/weather-exporter/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: prometheus-json-exporter
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 0.19.2
+digest: sha256:bb7108dbab266b0a8e8c4789cd284caa6f86d451410057e01daa0a581aeeddde
+generated: "2026-08-15T01:24:02.128607+02:00"

--- a/gitops/monitoring/weather-exporter/Chart.yaml
+++ b/gitops/monitoring/weather-exporter/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: weather-exporter
+description: Outside weather metrics from Open-Meteo via prometheus-json-exporter
+version: 0.1.0
+sources:
+  - https://github.com/prometheus-community/json_exporter
+  - https://open-meteo.com/en/docs
+dependencies:
+- name: prometheus-json-exporter
+  version: "0.19.2"
+  repository: https://prometheus-community.github.io/helm-charts

--- a/gitops/monitoring/weather-exporter/Makefile
+++ b/gitops/monitoring/weather-exporter/Makefile
@@ -1,0 +1,11 @@
+HELM_RELEASE=weather-exporter
+NAMESPACE=monitoring
+
+dependency:
+	helm dependency update
+
+template:
+	helm template -n "${NAMESPACE}" "${HELM_RELEASE}" . -f values.yaml
+
+deploy:
+	helm upgrade --install --create-namespace -n "${NAMESPACE}" "${HELM_RELEASE}" . -f values.yaml

--- a/gitops/monitoring/weather-exporter/dashboards/homelab-temperatures.json
+++ b/gitops/monitoring/weather-exporter/dashboards/homelab-temperatures.json
@@ -1,0 +1,520 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "How do server temperatures track the outside temperature in Paris? Outside data comes from Open-Meteo (weather-exporter), server data from node_exporter hwmon/thermal sensors.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current outside temperature in Paris (Open-Meteo, refreshed every 15 min)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              },
+              {
+                "color": "green",
+                "value": 10
+              },
+              {
+                "color": "orange",
+                "value": 25
+              },
+              {
+                "color": "red",
+                "value": 32
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg(weather_temperature_celsius{city=\"paris\"})",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Outside temperature (Paris)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current outside relative humidity in Paris (Open-Meteo)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg(weather_relative_humidity_percent{city=\"paris\"})",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Outside humidity (Paris)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current CPU temperature per node: thermal zone on the Raspberry Pis, coretemp package on the jonbonas Proxmox host",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "max": 90,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "orange",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 78
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 16,
+        "x": 8,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "displayMode": "basic",
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(node_thermal_zone_temp{type=\"cpu-thermal\"} or node_hwmon_temp_celsius{chip=\"platform_coretemp_0\",sensor=\"temp1\"}) * on(instance) group_left(nodename) node_uname_info",
+          "instant": true,
+          "legendFormat": "{{nodename}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU temperature by node (now)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "CPU temperature of each server against the outside temperature in Paris. Parallel movement means the servers are tracking ambient temperature; a diverging line means load or cooling changed on that node.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Paris (outside)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(node_thermal_zone_temp{type=\"cpu-thermal\"} or node_hwmon_temp_celsius{chip=\"platform_coretemp_0\",sensor=\"temp1\"}) * on(instance) group_left(nodename) node_uname_info",
+          "interval": "1m",
+          "legendFormat": "{{nodename}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg(weather_temperature_celsius{city=\"paris\"})",
+          "interval": "2m",
+          "legendFormat": "Paris (outside)",
+          "refId": "B"
+        }
+      ],
+      "title": "CPU temperature vs outside (Paris)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "CPU temperature minus outside temperature. This removes the weather from the picture: a flat line means the node only follows ambient temperature, a rising line means its own load or cooling changed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(node_thermal_zone_temp{type=\"cpu-thermal\"} or node_hwmon_temp_celsius{chip=\"platform_coretemp_0\",sensor=\"temp1\"}) * on(instance) group_left(nodename) node_uname_info - on() group_left() avg(weather_temperature_celsius{city=\"paris\"})",
+          "interval": "2m",
+          "legendFormat": "{{nodename}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU temperature delta above outside",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "NVMe (nvme_*) and SATA HDD (target*, via drivetemp) temperatures on the jonbonas Proxmox host. HDDs are happiest below 45C.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_hwmon_temp_celsius{job=\"node-exporter-jonbonas\",chip=~\"nvme_nvme.*|target.*\",sensor=\"temp1\"}",
+          "interval": "1m",
+          "legendFormat": "{{chip}}",
+          "refId": "A"
+        }
+      ],
+      "title": "jonbonas disk temperatures",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": [
+    "homelab",
+    "temperature"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Homelab temperatures vs outside",
+  "uid": "homelab-temperatures",
+  "weekStart": ""
+}

--- a/gitops/monitoring/weather-exporter/templates/dashboard-homelab-temperatures.yaml
+++ b/gitops/monitoring/weather-exporter/templates/dashboard-homelab-temperatures.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-homelab-temperatures
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    k8s-sidecar-target-directory: /tmp/dashboards/Homelab
+data:
+  homelab-temperatures.json: |-
+{{ .Files.Get "dashboards/homelab-temperatures.json" | indent 4 }}

--- a/gitops/monitoring/weather-exporter/values.yaml
+++ b/gitops/monitoring/weather-exporter/values.yaml
@@ -1,0 +1,37 @@
+prometheus-json-exporter:
+  configuration:
+    config: |
+      ---
+      modules:
+        openmeteo:
+          metrics:
+            - name: weather_temperature_celsius
+              path: "{.current.temperature_2m}"
+              help: Outside temperature in Celsius (Open-Meteo)
+            - name: weather_apparent_temperature_celsius
+              path: "{.current.apparent_temperature}"
+              help: Outside apparent temperature in Celsius (Open-Meteo)
+            - name: weather_relative_humidity_percent
+              path: "{.current.relative_humidity_2m}"
+              help: Outside relative humidity in percent (Open-Meteo)
+
+  serviceMonitor:
+    enabled: true
+    defaults:
+      # Open-Meteo refreshes its current weather every 15 min, but keep the
+      # scrape interval under Prometheus' 5m staleness window
+      interval: 2m
+      scrapeTimeout: 30s
+    targets:
+      - name: paris
+        url: https://api.open-meteo.com/v1/forecast?latitude=48.8566&longitude=2.3522&current=temperature_2m,relative_humidity_2m,apparent_temperature
+        module: openmeteo
+        additionalMetricsRelabels:
+          city: paris
+
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      memory: 64Mi

--- a/proxmox/playbooks/proxmox-node-exporter.yaml
+++ b/proxmox/playbooks/proxmox-node-exporter.yaml
@@ -1,0 +1,31 @@
+#################################################
+# Install prometheus-node-exporter on Proxmox (jonbonas)
+# Exposes hwmon temperatures (CPU, NVMe, SATA HDDs via drivetemp)
+# Scraped by the in-cluster Prometheus (see gitops/monitoring/kps)
+#################################################
+---
+- hosts: proxmox
+  become: true
+  tasks:
+    - name: Install prometheus-node-exporter
+      apt:
+        name:
+          - prometheus-node-exporter
+        update_cache: yes
+        state: present
+
+    - name: Load drivetemp kernel module for SATA disk temperatures
+      community.general.modprobe:
+        name: drivetemp
+        state: present
+
+    - name: Load drivetemp at boot
+      copy:
+        content: "drivetemp\n"
+        dest: /etc/modules-load.d/drivetemp.conf
+
+    - name: Enable and start prometheus-node-exporter
+      systemd:
+        name: prometheus-node-exporter
+        enabled: yes
+        state: started


### PR DESCRIPTION
## What

A Grafana dashboard correlating the outside temperature in Paris with the CPU/disk temperatures of the homelab servers, plus the plumbing to get both metrics into Prometheus.

### weather-exporter (new chart, `gitops/monitoring/weather-exporter`)

- `prometheus-json-exporter` scraping the **Open-Meteo** current weather API for Paris every 2 min (free, no API key — same API meteo-mangococo uses)
- Exposes `weather_temperature_celsius`, `weather_apparent_temperature_celsius`, `weather_relative_humidity_percent` with `city="paris"`
- Ships the dashboard **Homelab temperatures vs outside** (`uid: homelab-temperatures`, folder *Homelab*) via a sidecar ConfigMap:
  - stats: outside temp + humidity, CPU temp per node (bar gauge)
  - main panel: per-node CPU temp vs Paris outside temp (outside = dashed blue line)
  - delta panel: CPU temp minus outside temp (removes the weather from the picture)
  - jonbonas NVMe + HDD temperatures

### jonbonas host temperatures

The k8s-worker-1 VM can't see the physical sensors, so:

- new `proxmox-node-exporter` playbook (+ `make proxmox-node-exporter`): installs `prometheus-node-exporter` on the Proxmox host and loads the `drivetemp` kernel module so the 4 tank HDD temperatures appear in hwmon — **already applied by hand to jonbonas**, metrics verified (coretemp 54°C, NVMe 38-48°C, HDDs 42-44°C)
- kps `additionalScrapeConfigs` job `node-exporter-jonbonas` → `192.168.1.30:9100`

### History backfill (already done, one-off)

The exporter only collects forward, so the last 29 days of Paris weather (15-min resolution, interpolated to 2-min samples) were backfilled into the Prometheus TSDB with `promtool tsdb create-blocks-from openmetrics`. The dashboard correlates over the full 30d retention window from day one — the July 30 (38°C) and mid-August (36-39°C) heatwaves are visible.

## Notes

- Anything older than 30d is bounded by Prometheus retention (node temps included). Raising `retention` in kps is the knob if a longer window is ever wanted.
- Noticed while doing this: **Tailscale on jonbonas is logged out** ("Logged out." from `tailscale status`); I reached the host via its LAN IP. Worth a `tailscale up` at some point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)