### PR TITLE
feat(burrito): phase 1, operator + datastore, no layers yet

### DIFF
--- a/gitops/argocd/apps/values.yaml
+++ b/gitops/argocd/apps/values.yaml
@@ -148,6 +148,15 @@ applications:
       include: "*.yaml"
 
   # =============================================================================
+  # Burrito (Terraform automation)
+  # =============================================================================
+  - name: burrito
+    namespace: burrito-system
+    path: gitops/burrito-system/burrito
+    syncOptions:
+      - ServerSideApply=true
+
+  # =============================================================================
   # CNPG (CloudNative PostgreSQL)
   # =============================================================================
   - name: cloudnative-pg

--- a/gitops/burrito-system/burrito/Chart.lock
+++ b/gitops/burrito-system/burrito/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: burrito
+  repository: oci://ghcr.io/padok-team/charts
+  version: 0.13.0
+digest: sha256:fc7080b9550ec0ab9ce726ec0f27eadf5698f75ae5b6283049cfdbbfdf9eda35
+generated: "2026-08-15T12:40:10.946751+02:00"

--- a/gitops/burrito-system/burrito/Chart.yaml
+++ b/gitops/burrito-system/burrito/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: burrito
+description: Burrito TACoS operator (wraps the upstream OCI chart)
+version: 0.1.0
+
+dependencies:
+  - name: burrito
+    version: "0.13.0"
+    repository: oci://ghcr.io/padok-team/charts

--- a/gitops/burrito-system/burrito/Makefile
+++ b/gitops/burrito-system/burrito/Makefile
@@ -1,0 +1,16 @@
+HELM_RELEASE=burrito
+NAMESPACE=burrito-system
+
+template:
+	helm template -n "${NAMESPACE}" "${HELM_RELEASE}" . -f values.yaml > manifests.yaml
+
+deploy:
+	helm upgrade --install -n "${NAMESPACE}" --create-namespace "${HELM_RELEASE}" . -f values.yaml
+
+status:
+	helm status -n "${NAMESPACE}" "${HELM_RELEASE}"
+
+uninstall:
+	helm uninstall -n "${NAMESPACE}" "${HELM_RELEASE}"
+
+.PHONY: template deploy status uninstall

--- a/gitops/burrito-system/burrito/templates/basic-auth-middleware.yaml
+++ b/gitops/burrito-system/burrito/templates/basic-auth-middleware.yaml
@@ -1,0 +1,7 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: basic-auth
+spec:
+  basicAuth:
+    secret: basic-auth

--- a/gitops/burrito-system/burrito/templates/external-secret-admin-credentials.yaml
+++ b/gitops/burrito-system/burrito/templates/external-secret-admin-credentials.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: burrito-admin-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: burrito-admin-credentials
+    template:
+      type: kubernetes.io/basic-auth
+      engineVersion: v2
+      data:
+        username: admin
+        password: '{{ "{{ .password }}" }}'
+  data:
+    - secretKey: password
+      remoteRef:
+        key: burrito-admin-password

--- a/gitops/burrito-system/burrito/templates/external-secret-basic-auth.yaml
+++ b/gitops/burrito-system/burrito/templates/external-secret-basic-auth.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: basic-auth
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: basic-auth
+    template:
+      engineVersion: v2
+      data:
+        users: '{{ "{{ .username }}:{{ .password | bcrypt }}" }}'
+  data:
+    - secretKey: username
+      remoteRef:
+        key: basic-auth-username
+    - secretKey: password
+      remoteRef:
+        key: basic-auth-password

--- a/gitops/burrito-system/burrito/templates/external-secret-datastore-encryption.yaml
+++ b/gitops/burrito-system/burrito/templates/external-secret-datastore-encryption.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: burrito-datastore-encryption-key
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: burrito-datastore-encryption-key
+  data:
+    - secretKey: BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY
+      remoteRef:
+        key: burrito-datastore-encryption-key

--- a/gitops/burrito-system/burrito/templates/external-secret-datastore-s3.yaml
+++ b/gitops/burrito-system/burrito/templates/external-secret-datastore-s3.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: burrito-datastore-s3
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: burrito-datastore-s3
+    template:
+      engineVersion: v2
+      data:
+        AWS_ACCESS_KEY_ID: '{{ "{{ .accessKeyId }}" }}'
+        AWS_SECRET_ACCESS_KEY: '{{ "{{ .secretAccessKey }}" }}'
+        AWS_ENDPOINT_URL_S3: https://s3.fr-par.scw.cloud
+        AWS_REGION: fr-par
+  data:
+    - secretKey: accessKeyId
+      remoteRef:
+        key: burrito-datastore-access-key-id
+    - secretKey: secretAccessKey
+      remoteRef:
+        key: burrito-datastore-secret-access-key

--- a/gitops/burrito-system/burrito/templates/ingress-webhook.yaml
+++ b/gitops/burrito-system/burrito/templates/ingress-webhook.yaml
@@ -1,0 +1,23 @@
+# GitHub webhook deliveries must bypass the basic-auth middleware; the webhook
+# secret authenticates them. The TLS secret is issued by the chart's UI ingress.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: burrito-server-webhook
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: burrito.dixneuf19.fr
+      http:
+        paths:
+          - path: /api/webhook
+            pathType: Prefix
+            backend:
+              service:
+                name: burrito-server
+                port:
+                  number: 80
+  tls:
+    - secretName: burrito-dixneuf19-fr-tls
+      hosts:
+        - burrito.dixneuf19.fr

--- a/gitops/burrito-system/burrito/values.yaml
+++ b/gitops/burrito-system/burrito/values.yaml
@@ -1,0 +1,50 @@
+burrito:
+  config:
+    burrito:
+      controller:
+        timers:
+          driftDetection: 24h
+          repositorySync: 24h
+        maxConcurrentRunnerPods: 2
+        terraformMaxRetries: 2
+      datastore:
+        storage:
+          s3:
+            bucket: dixneuf19-burrito-datastore
+            usePathStyle: true
+          encryption:
+            enabled: true
+      server:
+        session:
+          secure: true
+
+  datastore:
+    tls:
+      enabled: true
+    deployment:
+      envFrom:
+        - secretRef:
+            name: burrito-datastore-s3
+        - secretRef:
+            name: burrito-datastore-encryption-key
+
+  server:
+    ingress:
+      enabled: true
+      ingressClassName: traefik
+      metadata:
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt
+          traefik.ingress.kubernetes.io/router.middlewares: burrito-system-basic-auth@kubernetescrd
+      host: burrito.dixneuf19.fr
+      tls:
+        - secretName: burrito-dixneuf19-fr-tls
+          hosts:
+            - burrito.dixneuf19.fr
+
+  tenants:
+    - namespace:
+        create: true
+        name: burrito-homelab
+      serviceAccounts:
+        - name: runner-homelab

--- a/terraform/bitwarden/secrets.tf
+++ b/terraform/bitwarden/secrets.tf
@@ -59,3 +59,37 @@ resource "bitwarden-secrets_secret" "karakeep_meili_master_key" {
   project_id = var.bw_project_id
   note       = "MeiliSearch master key for Karakeep"
 }
+
+resource "bitwarden-secrets_secret" "burrito_datastore_encryption_key" {
+  key        = "burrito-datastore-encryption-key"
+  project_id = var.bw_project_id
+  note       = "Burrito datastore encryption-at-rest key (auto-generated)"
+
+  length  = 64
+  special = false
+}
+
+resource "bitwarden-secrets_secret" "burrito_admin_password" {
+  key        = "burrito-admin-password"
+  project_id = var.bw_project_id
+  note       = "Burrito UI admin password (auto-generated)"
+
+  length  = 32
+  special = false
+}
+
+resource "bitwarden-secrets_secret" "burrito_datastore_access_key_id" {
+  key        = "burrito-datastore-access-key-id"
+  project_id = var.bw_project_id
+  note       = "Scaleway API key ID for the Burrito datastore"
+
+  value = data.terraform_remote_state.scaleway.outputs.burrito_datastore_access_key_id
+}
+
+resource "bitwarden-secrets_secret" "burrito_datastore_secret_access_key" {
+  key        = "burrito-datastore-secret-access-key"
+  project_id = var.bw_project_id
+  note       = "Scaleway API secret key for the Burrito datastore"
+
+  value = data.terraform_remote_state.scaleway.outputs.burrito_datastore_secret_access_key
+}

--- a/terraform/scaleway/burrito_datastore.tf
+++ b/terraform/scaleway/burrito_datastore.tf
@@ -1,0 +1,56 @@
+# Object Storage permission sets are project-scoped, never bucket-scoped, so the
+# datastore credentials live in their own project, away from dixneuf19-tfstates.
+resource "scaleway_account_project" "burrito_datastore" {
+  name        = "burrito-datastore"
+  description = "Burrito TACoS datastore (plan artifacts, runner logs, git bundles)"
+}
+
+resource "scaleway_object_bucket" "burrito_datastore" {
+  name       = "dixneuf19-burrito-datastore"
+  region     = "fr-par"
+  project_id = scaleway_account_project.burrito_datastore.id
+
+  # Burrito never deletes datastore objects itself (documented gap)
+  lifecycle_rule {
+    id      = "expire-artifacts"
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
+}
+
+resource "scaleway_iam_application" "burrito_datastore" {
+  name        = "burrito-datastore"
+  description = "Burrito datastore access to dixneuf19-burrito-datastore"
+}
+
+resource "scaleway_iam_policy" "burrito_datastore" {
+  name           = "burrito-datastore"
+  description    = "Object Storage access limited to the burrito-datastore project"
+  application_id = scaleway_iam_application.burrito_datastore.id
+
+  rule {
+    project_ids = [scaleway_account_project.burrito_datastore.id]
+
+    permission_set_names = [
+      "ObjectStorageBucketsRead",
+      "ObjectStorageObjectsRead",
+      "ObjectStorageObjectsWrite",
+      "ObjectStorageObjectsDelete",
+    ]
+  }
+}
+
+resource "scaleway_iam_api_key" "burrito_datastore" {
+  application_id = scaleway_iam_application.burrito_datastore.id
+  description    = "Burrito datastore"
+
+  # S3 clients cannot pass a project ID, the key's default project is used instead.
+  default_project_id = scaleway_account_project.burrito_datastore.id
+
+  # Org policy mandates an expiry. The datastore breaks past this date,
+  # rotate by bumping it and re-running both TF roots.
+  expires_at = "2027-08-15T00:00:00Z"
+}

--- a/terraform/scaleway/outputs.tf
+++ b/terraform/scaleway/outputs.tf
@@ -9,3 +9,15 @@ output "cnpg_backup_secret_access_key" {
   value       = scaleway_iam_api_key.cnpg_backups.secret_key
   sensitive   = true
 }
+
+output "burrito_datastore_access_key_id" {
+  description = "Scaleway API key ID for the Burrito datastore"
+  value       = scaleway_iam_api_key.burrito_datastore.access_key
+  sensitive   = true
+}
+
+output "burrito_datastore_secret_access_key" {
+  description = "Scaleway API secret key for the Burrito datastore"
+  value       = scaleway_iam_api_key.burrito_datastore.secret_key
+  sensitive   = true
+}


### PR DESCRIPTION
## What

Phase 1 of the Burrito (TACoS) rollout: install the **v0.13.0 operator** with its datastore, **zero layers**. The `TerraformRepository` + first layer (scaleway) come in the phase 2 PR.

### Terraform

- `terraform/scaleway/burrito_datastore.tf`: dedicated Scaleway project + `dixneuf19-burrito-datastore` bucket (90-day expiry on everything, since the burrito datastore never deletes its own objects) + project-scoped IAM app/policy/key, mirroring the cnpg-backups pattern. Key expires 2027-08-15.
- `terraform/bitwarden/secrets.tf`: 4 new BWS entries — datastore S3 keys (from the scaleway remote state), auto-generated datastore encryption key (64 chars) and UI admin password.

### gitops/burrito-system/burrito (umbrella chart, OCI dep pinned 0.13.0)

- Datastore on S3 (`usePathStyle`, Scaleway fr-par endpoint via env) with **encryption at rest** and in-cluster TLS (chart-managed CA via cert-manager).
- UI ingress at `burrito.dixneuf19.fr` behind the usual `basic-auth` Traefik middleware (ESO bcrypt `users` template, same shared credentials as the other public apps). Burrito's own login sits behind it, with `burrito-admin-credentials` pre-seeded via ESO (type `kubernetes.io/basic-auth`, username `admin`).
- Second ingress `burrito-server-webhook` exposes only `/api/webhook` **without** the middleware: GitHub webhook deliveries authenticate with the webhook secret (configured in phase 5). Reuses the UI ingress's TLS secret.
- **Gentle timers**: `repositorySync: 24h`, `driftDetection: 24h` — the webhook provides reactivity; polling and drift detection each spawn runner pods, so they stay at once a day. `maxConcurrentRunnerPods: 2`.
- Tenant namespace `burrito-homelab` + `runner-homelab` ServiceAccount created by the chart.
- ArgoCD app with `ServerSideApply=true` (burrito CRDs exceed the 262144B annotation limit).

## Why v0.13.0 minimum

v0.12.0 has a critical webhook-handling vulnerability, fixed in 0.13.0 (2026-07-31).

## Verification

- `helm template` renders all 40 resources; checked the generated `burrito-config` (timers, S3 bucket, encryption enabled, session secure), both ingresses (middleware annotation on the UI one only), datastore `envFrom`, and that the ESO template placeholders survive Helm rendering.
- `terraform validate` green on both roots; `terraform plan` on scaleway shows exactly the 5 new datastore resources, zero changes elsewhere. The bitwarden plan needs the scaleway apply first (reads its remote state outputs).

## After merge (manual, in order)

1. `cd terraform/scaleway && terraform apply`
2. `cd terraform/bitwarden && terraform apply`
3. Let ArgoCD sync; exit criteria: datastore Healthy against S3, `https://burrito.dixneuf19.fr` prompts basic-auth then the burrito login, `curl https://burrito.dixneuf19.fr/api/webhook` reaches the server without the auth prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)