### PR TITLE
docs(github): fix bws create for the PEM, add key fingerprint check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Temporary Items
 ### Secrets ###
 **/*.secret
 *.htpasswd
+*.pem
 
 ### Terraform ###
 **/.terraform/*

--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -45,10 +45,14 @@ needed for burrito.
    bws secret create burrito-github-app-id <APP_ID> 23028f7d-c2dd-4049-a1ef-b42300e91f30
    ```
 
-4. Still on the app page, "Generate a private key" (downloads a `.pem`), then:
+4. Still on the app page, "Generate a private key" (downloads a `.pem`), then
+   store it (the `--` is required: the PEM value starts with `-----` and would
+   otherwise be parsed as a flag) and check it against the `SHA256:...`
+   fingerprint shown on the app page before deleting the file:
 
    ```bash
-   bws secret create burrito-github-app-private-key "$(cat ~/Downloads/burrito-brassberry.*.private-key.pem)" 23028f7d-c2dd-4049-a1ef-b42300e91f30
+   bws secret create burrito-github-app-private-key -- "$(cat ~/Downloads/burrito-brassberry.*.private-key.pem)" 23028f7d-c2dd-4049-a1ef-b42300e91f30
+   openssl rsa -in ~/Downloads/burrito-brassberry.*.private-key.pem -pubout -outform DER | openssl sha256 -binary | openssl base64
    rm ~/Downloads/burrito-brassberry.*.private-key.pem
    ```
 


### PR DESCRIPTION
Two fixes surfaced while executing the GitHub App procedure from #1680:

- `bws secret create` for the private key needs `--` before the value: the PEM starts with `-----BEGIN`, which the CLI parses as a flag.
- Added the key verification step: `openssl rsa -pubout -outform DER | openssl sha256 -binary | openssl base64` reproduces the `SHA256:` fingerprint GitHub shows on the app page, so the stored key can be checked before deleting the download.
- `.gitignore` now covers `*.pem`, so a downloaded app key sitting in the tree can never be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)