### PR TITLE
docs(github): make steps 6-7 explicit about folders and apply order

### DIFF
--- a/terraform/bitwarden/github_app.tf
+++ b/terraform/bitwarden/github_app.tf
@@ -1,9 +1,7 @@
 # ── burrito-brassberry GitHub App ─────────────────────────────────────────────
 # The app is created once by hand and these secrets are written with bws during
-# that procedure (terraform/github/README.md). Terraform adopts them: add import
-# blocks with the IDs from
-#   bws secret list --output json | jq -r '.[] | select(.key | test("github")) | "\(.key) = \(.id)"'
-# then plan/apply and drop the import blocks.
+# that procedure (terraform/github/README.md). Terraform adopts them via the
+# import blocks in imports.tf.
 
 resource "bitwarden-secrets_secret" "burrito_github_app_id" {
   key        = "burrito-github-app-id"

--- a/terraform/bitwarden/imports.tf
+++ b/terraform/bitwarden/imports.tf
@@ -1,0 +1,22 @@
+# Adoption of the GitHub App secrets created by hand (terraform/github/README.md).
+# Import blocks are no-ops once the secrets are in the state.
+
+import {
+  to = bitwarden-secrets_secret.burrito_github_app_id
+  id = "493c6502-092e-4bfa-887b-b4a700b75e4f"
+}
+
+import {
+  to = bitwarden-secrets_secret.burrito_github_app_installation_id
+  id = "e0c999af-972c-460a-8457-b4a700b9579e"
+}
+
+import {
+  to = bitwarden-secrets_secret.burrito_github_app_private_key
+  id = "cb013741-5f0d-4fbe-a744-b4a700b827a6"
+}
+
+import {
+  to = bitwarden-secrets_secret.burrito_github_webhook_secret
+  id = "db403ea6-90b3-4680-835f-b4a700b6a5c4"
+}

--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -86,16 +86,14 @@ needed for burrito.
    ```
 
 7. Finally in **`terraform/github`** (reads the bitwarden remote state, so
-   step 6 must be applied first):
+   step 6 must be applied first). The adoptions (app installation binding,
+   pre-existing ArgoCD hook) are committed as import blocks in `imports.tf`:
 
    ```bash
    direnv reload            # picks up TF_VAR_burrito_github_app_installation_id
    cd terraform/github
    terraform init
-   # the app was installed on the repo in step 5, adopt the binding:
-   terraform import github_app_installation_repository.burrito_brassberry_gitops <installation-id>:brassberry-gitops
-   # pre-existing ArgoCD hook (see the ArgoCD webhook section below):
-   terraform import github_repository_webhook.argocd brassberry-gitops/442446137
+   terraform plan           # expect: 2 to import
    terraform apply
    ```
 
@@ -115,11 +113,8 @@ read here through its remote state). ArgoCD receives the same value through an
 `ExternalSecret` merged into `argocd-secret`
 (`gitops/argocd/argo-cd/templates/external-secret-webhook.yaml`).
 
-Adopt the existing hook before the first apply:
-
-```bash
-terraform import github_repository_webhook.argocd brassberry-gitops/442446137
-```
+The existing hook (id 442446137) is adopted by an import block in
+`imports.tf`.
 
 Apply order for the secret: `terraform/bitwarden` first (creates the secret),
 then this root (sets it on the hook). ArgoCD accepts unsigned deliveries until

--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -71,34 +71,18 @@ needed for burrito.
    `Unsupported attribute ... outputs` error on plan means a source root is
    behind).
 
+   The import blocks are committed in `terraform/bitwarden/imports.tf` (secret
+   IDs, not values; they are no-ops once the secrets are in the state). If a
+   secret was ever recreated, refresh the IDs with
+   `bws secret list --output json | jq -r '.[] | select(.key | test("github")) | "\(.key) = \(.id)"'`.
+
    ```bash
    cd terraform/scaleway
    terraform apply          # only if it has pending changes
 
    cd ../bitwarden
-   # one-time imports.tf; get the IDs with:
-   #   bws secret list --output json | jq -r '.[] | select(.key | test("github")) | "\(.key) = \(.id)"'
-   cat > imports.tf <<'EOF'
-   import {
-     to = bitwarden-secrets_secret.burrito_github_app_id
-     id = "<ID>"
-   }
-   import {
-     to = bitwarden-secrets_secret.burrito_github_app_installation_id
-     id = "<ID>"
-   }
-   import {
-     to = bitwarden-secrets_secret.burrito_github_app_private_key
-     id = "<ID>"
-   }
-   import {
-     to = bitwarden-secrets_secret.burrito_github_webhook_secret
-     id = "<ID>"
-   }
-   EOF
    terraform plan           # expect: 4 to import, no duplicate creates
    terraform apply
-   rm imports.tf
    ```
 
 7. Finally in **`terraform/github`** (reads the bitwarden remote state, so

--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -65,15 +65,53 @@ needed for burrito.
    bws secret create burrito-github-app-installation-id <ID> 23028f7d-c2dd-4049-a1ef-b42300e91f30
    ```
 
-6. Adopt the 4 secrets in `terraform/bitwarden` (import blocks, see
-   `terraform/bitwarden/github_app.tf`) and apply that root.
-
-7. `direnv reload`, then here:
+6. Adopt the 4 secrets in **`terraform/bitwarden`**. That root reads other
+   roots' remote state, so any root whose outputs it consumes must be applied
+   first (e.g. `terraform/scaleway` for the burrito datastore keys — an
+   `Unsupported attribute ... outputs` error on plan means a source root is
+   behind).
 
    ```bash
+   cd terraform/scaleway
+   terraform apply          # only if it has pending changes
+
+   cd ../bitwarden
+   # one-time imports.tf; get the IDs with:
+   #   bws secret list --output json | jq -r '.[] | select(.key | test("github")) | "\(.key) = \(.id)"'
+   cat > imports.tf <<'EOF'
+   import {
+     to = bitwarden-secrets_secret.burrito_github_app_id
+     id = "<ID>"
+   }
+   import {
+     to = bitwarden-secrets_secret.burrito_github_app_installation_id
+     id = "<ID>"
+   }
+   import {
+     to = bitwarden-secrets_secret.burrito_github_app_private_key
+     id = "<ID>"
+   }
+   import {
+     to = bitwarden-secrets_secret.burrito_github_webhook_secret
+     id = "<ID>"
+   }
+   EOF
+   terraform plan           # expect: 4 to import, no duplicate creates
+   terraform apply
+   rm imports.tf
+   ```
+
+7. Finally in **`terraform/github`** (reads the bitwarden remote state, so
+   step 6 must be applied first):
+
+   ```bash
+   direnv reload            # picks up TF_VAR_burrito_github_app_installation_id
+   cd terraform/github
    terraform init
    # the app was installed on the repo in step 5, adopt the binding:
    terraform import github_app_installation_repository.burrito_brassberry_gitops <installation-id>:brassberry-gitops
+   # pre-existing ArgoCD hook (see the ArgoCD webhook section below):
+   terraform import github_repository_webhook.argocd brassberry-gitops/442446137
    terraform apply
    ```
 

--- a/terraform/github/imports.tf
+++ b/terraform/github/imports.tf
@@ -1,0 +1,14 @@
+# Adoption of objects that predate this root. Import blocks are no-ops once
+# the resources are in the state.
+
+# The app installation on the repo is done by hand (README.md step 5).
+import {
+  to = github_app_installation_repository.burrito_brassberry_gitops
+  id = "${var.burrito_github_app_installation_id}:brassberry-gitops"
+}
+
+# ArgoCD push webhook, created by hand long before this root.
+import {
+  to = github_repository_webhook.argocd
+  id = "brassberry-gitops/442446137"
+}

--- a/terraform/github/webhook_argocd.tf
+++ b/terraform/github/webhook_argocd.tf
@@ -1,5 +1,4 @@
-# Pre-existing hook (id 442446137), import with:
-#   terraform import github_repository_webhook.argocd brassberry-gitops/442446137
+# Pre-existing hook, adopted via imports.tf.
 # Adding the secret authenticates deliveries; ArgoCD gets the same value through
 # an ExternalSecret merged into argocd-secret (webhook.github.secret).
 resource "github_repository_webhook" "argocd" {


### PR DESCRIPTION
Follow-up to #1680/#1681, from actually executing the procedure:

- Step 6 now says explicitly: apply `terraform/scaleway` first if pending (the bitwarden root reads its remote state; a plan failing with `Unsupported attribute ... outputs` means a source root is behind), then `cd terraform/bitwarden && terraform plan && terraform apply`.
- **Committed import blocks in both roots** instead of CLI import commands or heredocs:
  - `terraform/bitwarden/imports.tf`: the 4 hand-created GitHub App secrets (BWS secret IDs, not values).
  - `terraform/github/imports.tf`: the app installation binding (id references `var.burrito_github_app_installation_id`, so nothing account-specific is hardcoded) and the pre-existing ArgoCD hook (442446137).
  - Import blocks are no-ops once the resources are in the state, so both files live in the repo permanently.
- Steps 6 and 7 each shrink to `plan` (with the expected import count) + `apply`, with explicit `cd` for every command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)