### PR TITLE
fix(bitwarden): stop adopted secrets from being regenerated on apply

### DIFF
--- a/terraform/bitwarden/github_app.tf
+++ b/terraform/bitwarden/github_app.tf
@@ -1,30 +1,43 @@
 # ── burrito-brassberry GitHub App ─────────────────────────────────────────────
 # The app is created once by hand and these secrets are written with bws during
 # that procedure (terraform/github/README.md). Terraform adopts them via the
-# import blocks in imports.tf.
+# import blocks in imports.tf. ignore_changes is mandatory: without it the
+# provider regenerates the value on the first apply after import.
 
 resource "bitwarden-secrets_secret" "burrito_github_app_id" {
   key        = "burrito-github-app-id"
   project_id = var.bw_project_id
   note       = "burrito-brassberry GitHub App ID"
+  lifecycle {
+    ignore_changes = [value, length]
+  }
 }
 
 resource "bitwarden-secrets_secret" "burrito_github_app_installation_id" {
   key        = "burrito-github-app-installation-id"
   project_id = var.bw_project_id
   note       = "burrito-brassberry GitHub App installation ID"
+  lifecycle {
+    ignore_changes = [value, length]
+  }
 }
 
 resource "bitwarden-secrets_secret" "burrito_github_app_private_key" {
   key        = "burrito-github-app-private-key"
   project_id = var.bw_project_id
   note       = "burrito-brassberry GitHub App private key (PEM)"
+  lifecycle {
+    ignore_changes = [value, length]
+  }
 }
 
 resource "bitwarden-secrets_secret" "burrito_github_webhook_secret" {
   key        = "burrito-github-webhook-secret"
   project_id = var.bw_project_id
   note       = "burrito-brassberry GitHub App webhook secret"
+  lifecycle {
+    ignore_changes = [value, length]
+  }
 }
 
 # ── ArgoCD repo webhook ───────────────────────────────────────────────────────

--- a/terraform/bitwarden/secrets.tf
+++ b/terraform/bitwarden/secrets.tf
@@ -29,7 +29,10 @@ resource "bitwarden-secrets_secret" "cnpg_backup_secret_access_key" {
 }
 
 # ── Imported secrets ─────────────────────────────────────────────────────────
-# These already exist in Bitwarden. Terraform adopts them without recreating.
+# These already exist in Bitwarden. CAUTION: every generation attribute of this
+# provider is Optional+Computed, so an adopted resource without ignore_changes
+# gets its value REGENERATED on the first apply after import (happened
+# 2026-04-06 and 2026-08-15).
 #
 # To get the secret IDs, run:
 #   bws secret list --output json | jq -r '.[] | select(.key | test("baj-mysql|karakeep")) | "\(.key) = \(.id)"'
@@ -40,24 +43,36 @@ resource "bitwarden-secrets_secret" "baj_mysql_root_password" {
   key        = "baj-mysql-root-password"
   project_id = var.bw_project_id
   note       = "MySQL root password for og-baj-website"
+  lifecycle {
+    ignore_changes = [value, length]
+  }
 }
 
 resource "bitwarden-secrets_secret" "baj_mysql_password" {
   key        = "baj-mysql-password"
   project_id = var.bw_project_id
   note       = "MySQL app password for og-baj-website"
+  lifecycle {
+    ignore_changes = [value, length]
+  }
 }
 
 resource "bitwarden-secrets_secret" "karakeep_nextauth_secret" {
   key        = "karakeep-nextauth-secret"
   project_id = var.bw_project_id
   note       = "NextAuth session signing key for Karakeep"
+  lifecycle {
+    ignore_changes = [value, length]
+  }
 }
 
 resource "bitwarden-secrets_secret" "karakeep_meili_master_key" {
   key        = "karakeep-meili-master-key"
   project_id = var.bw_project_id
   note       = "MeiliSearch master key for Karakeep"
+  lifecycle {
+    ignore_changes = [value, length]
+  }
 }
 
 resource "bitwarden-secrets_secret" "burrito_datastore_encryption_key" {


### PR DESCRIPTION
## What happened

Running `terraform apply` in `terraform/bitwarden` after importing the 4 hand-created GitHub App secrets **rotated all 4 of them** (all revised in the same second, 11:33:56 today): the resulting values are 64-char generated strings instead of the app id / PEM / webhook secret / installation id. BWS revision history shows the same thing happened to the baj/karakeep secrets when they were adopted on 2026-04-06.

## Root cause

In this provider (bitwarden/bitwarden-secrets 0.5.4-pre), `value`, `length`, and all charset flags are Optional+**Computed**. A resource that declares neither `value` nor `length` (the "adopted" pattern) has those attributes unknown after import, and the next apply "completes" them by generating a fresh value.

## Fix

`lifecycle { ignore_changes = [value, length] }` on all 8 adopted resources (4 GitHub App + baj x2 + karakeep x2): Terraform keeps managing existence, key, note, and project, but never touches the value. Comments updated to warn about the sharp edge.

## Recovery (manual, after merge)

The 4 GitHub App entries need their real values re-stored (`bws secret edit --value=...`): app id from the app page, a freshly generated private key, a new webhook secret (also updated in the app's webhook form), installation id already fixed by hand. Then a `terraform plan` in the root must show **no changes** on those resources — that's the regression test for this fix.

karakeep/baj are unaffected today (stable since April).

🤖 Generated with [Claude Code](https://claude.com/claude-code)