### PR TITLE
chore(github): drop github_app_installation_repository

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -28,7 +28,6 @@ _bws_secret() {
 export TF_VAR_proxmox_api_token=$(_bws_secret proxmox-api-token)
 export TF_VAR_ssh_public_key=$(_bws_secret ssh-public-key)
 export TF_VAR_gandi_pat=$(_bws_secret gandi-pat)
-export TF_VAR_burrito_github_app_installation_id=$(_bws_secret burrito-github-app-installation-id)
 
 unset _BWS_CACHE
 unset -f _bws_secret

--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -1,7 +1,6 @@
 # terraform/github
 
-GitHub-side resources for brassberry-gitops: the burrito GitHub App installation
-scope and the ArgoCD push webhook.
+GitHub-side resources for brassberry-gitops: the ArgoCD push webhook.
 
 The provider authenticates with `GITHUB_TOKEN`, exported by the repo `.envrc`
 from `gh auth token`.
@@ -9,9 +8,11 @@ from `gh auth token`.
 ## The burrito-brassberry GitHub App
 
 GitHub has no API to create Apps, so the app itself cannot be a Terraform
-resource. It is created once by hand with the settings below; everything
-downstream (installation scope, secrets in Bitwarden, cluster consumption via
-ESO) is IaC.
+resource. It is created once by hand with the settings below; the secrets flow
+(Bitwarden, cluster consumption via ESO) is IaC. The installation scope is
+also managed by hand (step 5): the `/user/installations/*` endpoints behind
+`github_app_installation_repository` only accept a classic PAT, whose
+account-wide `repo` scope is not worth a single repo binding.
 
 The webhook is app-level: it is configured on the app itself and delivers the
 subscribed events for every installed repository. No separate repo webhook is
@@ -86,14 +87,13 @@ needed for burrito.
    ```
 
 7. Finally in **`terraform/github`** (reads the bitwarden remote state, so
-   step 6 must be applied first). The adoptions (app installation binding,
-   pre-existing ArgoCD hook) are committed as import blocks in `imports.tf`:
+   step 6 must be applied first). The pre-existing ArgoCD hook is adopted via
+   the import block in `imports.tf`:
 
    ```bash
-   direnv reload            # picks up TF_VAR_burrito_github_app_installation_id
    cd terraform/github
    terraform init
-   terraform plan           # expect: 2 to import
+   terraform plan           # expect: 1 to import, 1 to change (hook gains its secret)
    terraform apply
    ```
 

--- a/terraform/github/app_installation.tf
+++ b/terraform/github/app_installation.tf
@@ -1,7 +1,0 @@
-# The GitHub App itself cannot be Terraform-managed (GitHub has no API to create
-# apps); it is created once by hand, see README.md. This only pins which
-# repositories the installation covers.
-resource "github_app_installation_repository" "burrito_brassberry_gitops" {
-  installation_id = var.burrito_github_app_installation_id
-  repository      = "brassberry-gitops"
-}

--- a/terraform/github/imports.tf
+++ b/terraform/github/imports.tf
@@ -1,12 +1,6 @@
 # Adoption of objects that predate this root. Import blocks are no-ops once
 # the resources are in the state.
 
-# The app installation on the repo is done by hand (README.md step 5).
-import {
-  to = github_app_installation_repository.burrito_brassberry_gitops
-  id = "${var.burrito_github_app_installation_id}:brassberry-gitops"
-}
-
 # ArgoCD push webhook, created by hand long before this root.
 import {
   to = github_repository_webhook.argocd

--- a/terraform/github/variables.tf
+++ b/terraform/github/variables.tf
@@ -1,4 +1,0 @@
-variable "burrito_github_app_installation_id" {
-  description = "Installation ID of the burrito-brassberry GitHub App (BWS: burrito-github-app-installation-id)"
-  type        = string
-}


### PR DESCRIPTION
Executing the procedure showed that the `/user/installations/*` endpoints behind `github_app_installation_repository` reject `gh`'s OAuth token and require a **classic PAT** (403: "You must authenticate with an access token authorized to a GitHub App, a personal access token, or basic auth"). A classic PAT's `repo` scope is account-wide, which is not worth pinning a single repo↔installation binding, so the resource is dropped:

- `app_installation.tf`, `variables.tf`, its import block, and the `.envrc` `TF_VAR` are removed.
- The installation scope stays the one-click UI step (README step 5, unchanged) and the installation id stays in BWS — the burrito repository credential still needs it via ESO in phase 2.
- README updated: the root now only manages the ArgoCD webhook; step 7 expects `1 to import, 1 to change`.

Note: the resource never made it into the state (both plans errored before apply), so no `state rm` is needed. If `terraform state list` in `terraform/github` ever shows it anyway, remove it with `terraform state rm` rather than letting an apply destroy the binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)