### PR TITLE
feat(burrito): phase 2, TerraformRepository + scaleway layer, plan-only

### DIFF
--- a/gitops/argocd/apps/values.yaml
+++ b/gitops/argocd/apps/values.yaml
@@ -156,6 +156,11 @@ applications:
     syncOptions:
       - ServerSideApply=true
 
+  - name: burrito-layers
+    namespace: burrito-homelab
+    path: gitops/burrito-homelab/burrito-layers
+    createNamespace: false
+
   # =============================================================================
   # CNPG (CloudNative PostgreSQL)
   # =============================================================================

--- a/gitops/burrito-homelab/burrito-layers/Chart.yaml
+++ b/gitops/burrito-homelab/burrito-layers/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: burrito-layers
+description: Burrito TerraformRepository, layers, and runner credentials
+version: 0.1.0

--- a/gitops/burrito-homelab/burrito-layers/Makefile
+++ b/gitops/burrito-homelab/burrito-layers/Makefile
@@ -1,0 +1,16 @@
+HELM_RELEASE=burrito-layers
+NAMESPACE=burrito-homelab
+
+template:
+	helm template -n "${NAMESPACE}" "${HELM_RELEASE}" . -f values.yaml > manifests.yaml
+
+deploy:
+	helm upgrade --install -n "${NAMESPACE}" --create-namespace "${HELM_RELEASE}" . -f values.yaml
+
+status:
+	helm status -n "${NAMESPACE}" "${HELM_RELEASE}"
+
+uninstall:
+	helm uninstall -n "${NAMESPACE}" "${HELM_RELEASE}"
+
+.PHONY: template deploy status uninstall

--- a/gitops/burrito-homelab/burrito-layers/templates/external-secret-repo.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/external-secret-repo.yaml
@@ -1,0 +1,34 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: burrito-repo
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: burrito-repo
+    template:
+      type: credentials.burrito.tf/repository
+      engineVersion: v2
+      data:
+        provider: github
+        url: https://github.com/dixneuf19/brassberry-gitops
+        githubAppID: '{{ "{{ .appId }}" }}'
+        githubAppInstallationID: '{{ "{{ .installationId }}" }}'
+        githubAppPrivateKey: '{{ "{{ .privateKey }}" }}'
+        webhookSecret: '{{ "{{ .webhookSecret }}" }}'
+  data:
+    - secretKey: appId
+      remoteRef:
+        key: burrito-github-app-id
+    - secretKey: installationId
+      remoteRef:
+        key: burrito-github-app-installation-id
+    - secretKey: privateKey
+      remoteRef:
+        key: burrito-github-app-private-key
+    - secretKey: webhookSecret
+      remoteRef:
+        key: burrito-github-webhook-secret

--- a/gitops/burrito-homelab/burrito-layers/templates/external-secret-runner-common.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/external-secret-runner-common.yaml
@@ -1,0 +1,19 @@
+# State backend (S3 on Scaleway) credentials, shared by every layer's runner
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: burrito-runner-common
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: burrito-runner-common
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: burrito-runner-access-key-id
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: burrito-runner-secret-access-key

--- a/gitops/burrito-homelab/burrito-layers/templates/external-secret-runner-scaleway.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/external-secret-runner-scaleway.yaml
@@ -1,0 +1,33 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: burrito-runner-scaleway
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: burrito-runner-scaleway
+    template:
+      engineVersion: v2
+      data:
+        SCW_ACCESS_KEY: '{{ "{{ .accessKey }}" }}'
+        SCW_SECRET_KEY: '{{ "{{ .secretKey }}" }}'
+        SCW_DEFAULT_ORGANIZATION_ID: '{{ "{{ .organizationId }}" }}'
+        SCW_DEFAULT_PROJECT_ID: '{{ "{{ .projectId }}" }}'
+        SCW_DEFAULT_REGION: fr-par
+        SCW_DEFAULT_ZONE: fr-par-1
+  data:
+    - secretKey: accessKey
+      remoteRef:
+        key: burrito-runner-access-key-id
+    - secretKey: secretKey
+      remoteRef:
+        key: burrito-runner-secret-access-key
+    - secretKey: organizationId
+      remoteRef:
+        key: scaleway-organization-id
+    - secretKey: projectId
+      remoteRef:
+        key: scaleway-default-project-id

--- a/gitops/burrito-homelab/burrito-layers/templates/layer-scaleway.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/layer-scaleway.yaml
@@ -1,0 +1,17 @@
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: scaleway
+spec:
+  path: terraform/scaleway
+  branch: main
+  repository:
+    name: brassberry-gitops
+    namespace: burrito-homelab
+  overrideRunnerSpec:
+    # arrays replace wholesale on merge, so re-list burrito-runner-common
+    envFrom:
+      - secretRef:
+          name: burrito-runner-common
+      - secretRef:
+          name: burrito-runner-scaleway

--- a/gitops/burrito-homelab/burrito-layers/templates/repository.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/repository.yaml
@@ -1,0 +1,22 @@
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRepository
+metadata:
+  name: brassberry-gitops
+spec:
+  repository:
+    url: https://github.com/dixneuf19/brassberry-gitops
+  terraform:
+    enabled: true
+  remediationStrategy:
+    autoApply: false
+  overrideRunnerSpec:
+    serviceAccountName: runner-homelab
+    envFrom:
+      - secretRef:
+          name: burrito-runner-common
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        memory: 2Gi

--- a/gitops/burrito-homelab/burrito-layers/values.yaml
+++ b/gitops/burrito-homelab/burrito-layers/values.yaml
@@ -1,0 +1,1 @@
+# Plain templates, no values yet

--- a/gitops/burrito-system/burrito/templates/external-secret-admin-credentials.yaml
+++ b/gitops/burrito-system/burrito/templates/external-secret-admin-credentials.yaml
@@ -13,9 +13,12 @@ spec:
       type: kubernetes.io/basic-auth
       engineVersion: v2
       data:
-        username: admin
+        username: '{{ "{{ .username }}" }}'
         password: '{{ "{{ .password }}" }}'
   data:
+    - secretKey: username
+      remoteRef:
+        key: basic-auth-username
     - secretKey: password
       remoteRef:
-        key: burrito-admin-password
+        key: basic-auth-password

--- a/terraform/bitwarden/secrets.tf
+++ b/terraform/bitwarden/secrets.tf
@@ -84,14 +84,6 @@ resource "bitwarden-secrets_secret" "burrito_datastore_encryption_key" {
   special = false
 }
 
-resource "bitwarden-secrets_secret" "burrito_admin_password" {
-  key        = "burrito-admin-password"
-  project_id = var.bw_project_id
-  note       = "Burrito UI admin password (auto-generated)"
-
-  length  = 32
-  special = false
-}
 
 resource "bitwarden-secrets_secret" "burrito_datastore_access_key_id" {
   key        = "burrito-datastore-access-key-id"
@@ -107,4 +99,36 @@ resource "bitwarden-secrets_secret" "burrito_datastore_secret_access_key" {
   note       = "Scaleway API secret key for the Burrito datastore"
 
   value = data.terraform_remote_state.scaleway.outputs.burrito_datastore_secret_access_key
+}
+
+resource "bitwarden-secrets_secret" "burrito_runner_access_key_id" {
+  key        = "burrito-runner-access-key-id"
+  project_id = var.bw_project_id
+  note       = "Scaleway API key ID for burrito runner pods"
+
+  value = data.terraform_remote_state.scaleway.outputs.burrito_runner_access_key_id
+}
+
+resource "bitwarden-secrets_secret" "burrito_runner_secret_access_key" {
+  key        = "burrito-runner-secret-access-key"
+  project_id = var.bw_project_id
+  note       = "Scaleway API secret key for burrito runner pods"
+
+  value = data.terraform_remote_state.scaleway.outputs.burrito_runner_secret_access_key
+}
+
+resource "bitwarden-secrets_secret" "scaleway_organization_id" {
+  key        = "scaleway-organization-id"
+  project_id = var.bw_project_id
+  note       = "Scaleway organization ID"
+
+  value = data.terraform_remote_state.scaleway.outputs.scaleway_organization_id
+}
+
+resource "bitwarden-secrets_secret" "scaleway_default_project_id" {
+  key        = "scaleway-default-project-id"
+  project_id = var.bw_project_id
+  note       = "Scaleway default project ID"
+
+  value = data.terraform_remote_state.scaleway.outputs.scaleway_default_project_id
 }

--- a/terraform/scaleway/burrito_runner.tf
+++ b/terraform/scaleway/burrito_runner.tf
@@ -1,0 +1,36 @@
+data "scaleway_account_project" "homelab" {
+  name = "homelab"
+}
+
+resource "scaleway_iam_application" "burrito_runner" {
+  name        = "burrito-runner"
+  description = "Burrito runner pods: org-wide reads for plan, state backend writes"
+}
+
+resource "scaleway_iam_policy" "burrito_runner" {
+  name           = "burrito-runner"
+  description    = "Plan-only: read everything, write Object Storage on the default project (tfstates backend + locks)"
+  application_id = scaleway_iam_application.burrito_runner.id
+
+  rule {
+    organization_id      = data.scaleway_account_project.homelab.organization_id
+    permission_set_names = ["AllProductsReadOnly", "IAMReadOnly"]
+  }
+
+  rule {
+    project_ids          = [data.scaleway_account_project.homelab.id]
+    permission_set_names = ["ObjectStorageFullAccess"]
+  }
+}
+
+resource "scaleway_iam_api_key" "burrito_runner" {
+  application_id = scaleway_iam_application.burrito_runner.id
+  description    = "Burrito runner"
+
+  # S3 clients cannot pass a project ID, the key's default project is used instead.
+  default_project_id = data.scaleway_account_project.homelab.id
+
+  # Org policy mandates an expiry. Layer plans break past this date,
+  # rotate by bumping it and re-running both TF roots.
+  expires_at = "2027-08-15T00:00:00Z"
+}

--- a/terraform/scaleway/outputs.tf
+++ b/terraform/scaleway/outputs.tf
@@ -21,3 +21,25 @@ output "burrito_datastore_secret_access_key" {
   value       = scaleway_iam_api_key.burrito_datastore.secret_key
   sensitive   = true
 }
+
+output "burrito_runner_access_key_id" {
+  description = "Scaleway API key ID for burrito runner pods"
+  value       = scaleway_iam_api_key.burrito_runner.access_key
+  sensitive   = true
+}
+
+output "burrito_runner_secret_access_key" {
+  description = "Scaleway API secret key for burrito runner pods"
+  value       = scaleway_iam_api_key.burrito_runner.secret_key
+  sensitive   = true
+}
+
+output "scaleway_organization_id" {
+  description = "Scaleway organization ID"
+  value       = data.scaleway_account_project.homelab.organization_id
+}
+
+output "scaleway_default_project_id" {
+  description = "Scaleway homelab (provider default) project ID"
+  value       = data.scaleway_account_project.homelab.id
+}


### PR DESCRIPTION
## What

The first burrito layer. Everything stays `autoApply: false`.

### `gitops/burrito-homelab/burrito-layers` (new app)

Placed per the `gitops/<namespace>/<chart>` convention (the layers live in the tenant namespace, not `burrito-system`):

- **`burrito-repo`** ExternalSecret: type `credentials.burrito.tf/repository` (matched by the `url` key, the CRD has no secretName field), carrying the GitHub App id/installation/PEM and the webhook secret from BWS.
- **`burrito-runner-common`** (state backend `AWS_*`) and **`burrito-runner-scaleway`** (`SCW_*` + org/project ids + fr-par literals). Layers re-list `burrito-runner-common` in `envFrom` since override arrays replace wholesale.
- **`TerraformRepository`** (runner SA, 200m/512Mi requests, 2Gi limit) + **`TerraformLayer` scaleway** (`path: terraform/scaleway`, `branch: main`).

### Runner credentials: dedicated least-privilege Scaleway key

`terraform/scaleway` mints a `burrito-runner` IAM application/policy/key instead of putting laptop keys in BWS:
- org-wide `AllProductsReadOnly` + `IAMReadOnly` (enough for `terraform plan` on every root)
- `ObjectStorageFullAccess` on the **homelab project only** (state backend reads + `use_lockfile` writes)
- expiry 2027-08-15, same rotation note as the other keys. Write permissions come later, only if/when a layer gets `autoApply`.

`terraform/bitwarden` mirrors the key + org/project ids into BWS from the remote state. **No `TENV_GITHUB_TOKEN`**: tenv downloads Terraform from releases.hashicorp.com, so GitHub rate limits don't apply (v1 plan assumption dropped).

### Bonus: one login instead of two

`burrito-admin-credentials` now mirrors the shared `basic-auth-username`/`basic-auth-password` pair, so the Traefik prompt and the burrito login take the same credentials. The dedicated `burrito-admin-password` BWS entry is removed.

## Verification

- `helm template` renders the 5 resources; checked the repo secret type/keys, layer path, and envFrom list.
- `terraform plan` on scaleway: exactly the 3 new IAM resources. Both roots validate.

## After merge (in order)

1. `cd terraform/scaleway && terraform apply`
2. `cd terraform/bitwarden && terraform apply` (adds 4 entries, removes `burrito-admin-password`)
3. Let ArgoCD sync. Exit: green plan with zero diff on the scaleway layer in the burrito UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)