### PR TITLE
fix(scaleway): split burrito-runner policy rules by scope type

### DIFF
--- a/terraform/scaleway/burrito_runner.tf
+++ b/terraform/scaleway/burrito_runner.tf
@@ -12,9 +12,16 @@ resource "scaleway_iam_policy" "burrito_runner" {
   description    = "Plan-only: read everything, write Object Storage on the default project (tfstates backend + locks)"
   application_id = scaleway_iam_application.burrito_runner.id
 
+  # A rule cannot mix scope types: org-scope sets (IAM, projects) and
+  # projects-scope sets (products) go in separate rules.
   rule {
     organization_id      = data.scaleway_account_project.homelab.organization_id
-    permission_set_names = ["AllProductsReadOnly", "IAMReadOnly"]
+    permission_set_names = ["IAMReadOnly", "ProjectReadOnly"]
+  }
+
+  rule {
+    organization_id      = data.scaleway_account_project.homelab.organization_id
+    permission_set_names = ["AllProductsReadOnly"]
   }
 
   rule {


### PR DESCRIPTION
`terraform apply` after #1685 failed with:

> rules[0].permission_set_names does not respect constraint, permission sets must be of the same scope type

Verified against `scw iam permission-set list`: `IAMReadOnly` and `ProjectReadOnly` are **organization**-scope, `AllProductsReadOnly` is **projects**-scope. A rule cannot mix scope types, so the policy is now three rules:

1. org scope: `IAMReadOnly` + `ProjectReadOnly` (the second is new — the scaleway root manages account projects, so plans must read them)
2. all projects: `AllProductsReadOnly` (`organization_id` on a projects-scope set = all current and future projects)
3. homelab project only: `ObjectStorageFullAccess` (state backend + locks)

After merge: re-run `terraform apply` in `terraform/scaleway`, then `terraform/bitwarden`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)