### PR TITLE
feat(burrito): phase 3, cloud layer plan-only

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -28,6 +28,10 @@ _bws_secret() {
 export TF_VAR_proxmox_api_token=$(_bws_secret proxmox-api-token)
 export TF_VAR_ssh_public_key=$(_bws_secret ssh-public-key)
 export TF_VAR_gandi_pat=$(_bws_secret gandi-pat)
+export TF_VAR_github_user=$(_bws_secret github-user)
+export TF_VAR_oci_compartment_id=$(_bws_secret oci-compartment-id)
+export TF_VAR_tailscale_auth_key=$(_bws_secret tailscale-auth-key)
+export TF_VAR_node_ips=$(_bws_secret oci-node-ips)
 
 unset _BWS_CACHE
 unset -f _bws_secret

--- a/gitops/burrito-homelab/burrito-layers/templates/external-secret-runner-cloud.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/external-secret-runner-cloud.yaml
@@ -1,0 +1,41 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: burrito-runner-cloud
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: burrito-runner-cloud
+    template:
+      engineVersion: v2
+      data:
+        TF_VAR_gandi_pat: '{{ "{{ .gandiPat }}" }}'
+        TF_VAR_github_user: '{{ "{{ .githubUser }}" }}'
+        TF_VAR_oci_compartment_id: '{{ "{{ .compartmentId }}" }}'
+        TF_VAR_tailscale_auth_key: '{{ "{{ .tailscaleAuthKey }}" }}'
+        TF_VAR_node_ips: '{{ "{{ .nodeIps }}" }}'
+        TF_VAR_oci_private_key_path: /home/burrito/.oci/oci_api_key.pem
+        # mounted as a file by the layer's overrideRunnerSpec, not read as env
+        oci_api_key.pem: '{{ "{{ .ociPrivateKey }}" }}'
+  data:
+    - secretKey: gandiPat
+      remoteRef:
+        key: gandi-pat
+    - secretKey: githubUser
+      remoteRef:
+        key: github-user
+    - secretKey: compartmentId
+      remoteRef:
+        key: oci-compartment-id
+    - secretKey: tailscaleAuthKey
+      remoteRef:
+        key: tailscale-auth-key
+    - secretKey: nodeIps
+      remoteRef:
+        key: oci-node-ips
+    - secretKey: ociPrivateKey
+      remoteRef:
+        key: oci-api-private-key

--- a/gitops/burrito-homelab/burrito-layers/templates/layer-cloud.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/layer-cloud.yaml
@@ -1,0 +1,30 @@
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: cloud
+spec:
+  path: terraform/cloud
+  branch: main
+  repository:
+    name: brassberry-gitops
+    namespace: burrito-homelab
+  overrideRunnerSpec:
+    # arrays replace wholesale on merge, so re-list burrito-runner-common
+    envFrom:
+      - secretRef:
+          name: burrito-runner-common
+      - secretRef:
+          name: burrito-runner-cloud
+    volumes:
+      - name: oci-key
+        secret:
+          secretName: burrito-runner-cloud
+          items:
+            - key: oci_api_key.pem
+              path: oci_api_key.pem
+          defaultMode: 0400
+    volumeMounts:
+      - name: oci-key
+        mountPath: /home/burrito/.oci/oci_api_key.pem
+        subPath: oci_api_key.pem
+        readOnly: true

--- a/terraform/bitwarden/imports.tf
+++ b/terraform/bitwarden/imports.tf
@@ -20,3 +20,28 @@ import {
   to = bitwarden-secrets_secret.burrito_github_webhook_secret
   id = "db403ea6-90b3-4680-835f-b4a700b6a5c4"
 }
+
+import {
+  to = bitwarden-secrets_secret.github_user
+  id = "4a5f4a0d-5969-4e87-8f81-b4a700e613dc"
+}
+
+import {
+  to = bitwarden-secrets_secret.oci_compartment_id
+  id = "a57bab3f-ada8-4769-8157-b4a700e6140d"
+}
+
+import {
+  to = bitwarden-secrets_secret.oci_node_ips
+  id = "da31b3ef-ce27-4a71-85ac-b4a700e6143e"
+}
+
+import {
+  to = bitwarden-secrets_secret.tailscale_auth_key
+  id = "fb8ee74d-3c26-4a3e-b35e-b4a700e61490"
+}
+
+import {
+  to = bitwarden-secrets_secret.oci_api_private_key
+  id = "dcdcc394-4d04-4a40-9ac6-b4a700e634b9"
+}

--- a/terraform/bitwarden/secrets.tf
+++ b/terraform/bitwarden/secrets.tf
@@ -132,3 +132,55 @@ resource "bitwarden-secrets_secret" "scaleway_default_project_id" {
 
   value = data.terraform_remote_state.scaleway.outputs.scaleway_default_project_id
 }
+
+# ── Cloud layer (adopted, values written with bws; see the regen CAUTION above) ──
+
+resource "bitwarden-secrets_secret" "github_user" {
+  key        = "github-user"
+  project_id = var.bw_project_id
+  note       = "GitHub username for cloud-init user (cloud layer)"
+
+  lifecycle {
+    ignore_changes = [value, length]
+  }
+}
+
+resource "bitwarden-secrets_secret" "oci_compartment_id" {
+  key        = "oci-compartment-id"
+  project_id = var.bw_project_id
+  note       = "OCI compartment OCID (cloud layer)"
+
+  lifecycle {
+    ignore_changes = [value, length]
+  }
+}
+
+resource "bitwarden-secrets_secret" "oci_node_ips" {
+  key        = "oci-node-ips"
+  project_id = var.bw_project_id
+  note       = "Tailscale IPs of cluster nodes, JSON list for TF_VAR_node_ips (cloud layer)"
+
+  lifecycle {
+    ignore_changes = [value, length]
+  }
+}
+
+resource "bitwarden-secrets_secret" "tailscale_auth_key" {
+  key        = "tailscale-auth-key"
+  project_id = var.bw_project_id
+  note       = "Tailscale auth key baked into OCI instance user_data; rotate before any instance recreate"
+
+  lifecycle {
+    ignore_changes = [value, length]
+  }
+}
+
+resource "bitwarden-secrets_secret" "oci_api_private_key" {
+  key        = "oci-api-private-key"
+  project_id = var.bw_project_id
+  note       = "OCI API private key PEM (cloud layer provider)"
+
+  lifecycle {
+    ignore_changes = [value, length]
+  }
+}

--- a/terraform/cloud/_settings.tf
+++ b/terraform/cloud/_settings.tf
@@ -1,7 +1,7 @@
 provider "oci" {
   tenancy_ocid     = "ocid1.tenancy.oc1..aaaaaaaag3xw32hdfohhaxtbrgqn7bukopofevsijbhbh6y6fgo5u3vnirpq"
   user_ocid        = "ocid1.user.oc1..aaaaaaaa3bnkhue5jyet7ny2wdtj4y2ll4mcb57ijqv2eylpqnxbwkuovhea"
-  private_key_path = "~/.oci/oci_api_key.pem"
+  private_key_path = var.oci_private_key_path
   fingerprint      = "b0:56:46:49:33:1d:e5:b5:7d:64:26:c8:e7:ef:90:fc"
   region           = "eu-paris-1"
 }

--- a/terraform/cloud/variables.tf
+++ b/terraform/cloud/variables.tf
@@ -19,3 +19,8 @@ variable "gandi_pat" {
 variable "node_ips" {
   type = list(string)
 }
+
+variable "oci_private_key_path" {
+  type    = string
+  default = "~/.oci/oci_api_key.pem"
+}


### PR DESCRIPTION
## What

The `cloud` layer (OCI ARM worker + Gandi DNS), plan-only, plus making **BWS the single source of truth** for this root's inputs — until now they existed nowhere (`.envrc` and `perso/.env` never had them), which is why local plans failed.

### BWS as source of truth

5 entries created in BWS and adopted in `terraform/bitwarden` (with the `ignore_changes` guard from #1683, import blocks included): `github-user`, `oci-compartment-id`, `oci-node-ips`, `tailscale-auth-key`, `oci-api-private-key`.

The values were **recovered byte-exact from the state** (decoded instance `user_data`, plus `~/.oci/oci_api_key.pem`). Proof of exactness: the `all_vars` keeper on `random_id.hostname_suffix` shows **no diff** in the plan. `.envrc` now exports them as `TF_VAR_*` so local runs and burrito runs read the same source.

Dropped from the v1 plan: `DIGITALOCEAN_TOKEN` (the droplet is fully commented out, no DO variable exists).

### Layer

- `terraform/cloud`: `private_key_path` becomes `var.oci_private_key_path` (same local default), so the runner points at a mounted file.
- `burrito-runner-cloud` ExternalSecret: the `TF_VAR_*`s + the OCI PEM, mounted by the layer at `/home/burrito/.oci/oci_api_key.pem` (0400, `subPath`); `envFrom` skips the dotted key.
- `TerraformLayer cloud`, `path: terraform/cloud`, plan-only, re-lists `burrito-runner-common`.

## Known pending diff on this root (expected)

The local plan shows `2 to add, 1 to change, 2 to destroy`: Oracle published newer Ubuntu 22.04 aarch64 images and the root's `available_images` keeper deliberately forces an instance rebuild on image refresh. This is pre-existing, by-design drift that burrito will now surface — not caused by this PR (the vars keeper is unchanged).

⚠️ **Before ever applying this root** (locally or via burrito): mint a fresh Tailscale auth key and `bws secret edit` `tailscale-auth-key` — the baked key is long expired and a rebuilt node would not join the tailnet. Applying also means rotating the k8s worker VM (drain first).

## Verification

- `terraform validate` green on cloud + bitwarden; `helm template` renders the new ExternalSecret and layer correctly.
- Local `terraform plan` on the cloud root now works end to end with values from BWS via direnv.

## After merge

1. `cd terraform/bitwarden && terraform plan` (expect: 5 to import, no changes) `&& terraform apply`
2. ArgoCD syncs; the cloud layer should plan and show exactly the image-rebuild diff above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)