### PR TITLE
fix(burrito): make the mounted OCI key readable by the non-root runner

### DIFF
--- a/gitops/burrito-homelab/burrito-layers/templates/layer-cloud.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/layer-cloud.yaml
@@ -22,7 +22,7 @@ spec:
           items:
             - key: oci_api_key.pem
               path: oci_api_key.pem
-          defaultMode: 0400
+          defaultMode: 0444
     volumeMounts:
       - name: oci-key
         mountPath: /home/burrito/.oci/oci_api_key.pem


### PR DESCRIPTION
The cloud layer's first plan runs fail with:

> Error: can not create client, bad configuration: did not find a proper configuration for private key

Root cause: the burrito runner pod runs `runAsNonRoot` without an `fsGroup`, so secret volume files are owned `root:root` — with `defaultMode: 0400` the mounted OCI key is unreadable by the runner user. `0444` fixes it; the file is pod-local and stays read-only.

After merge, the fix syncs via ArgoCD and the push triggers a fresh plan run; expected result on the cloud layer is the known image-rebuild diff (`2 add, 1 change, 2 destroy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)