### PR TITLE
feat(burrito): phase 4, proxmox layer, plan-only forever

### DIFF
--- a/gitops/burrito-homelab/burrito-layers/templates/external-secret-runner-proxmox.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/external-secret-runner-proxmox.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: burrito-runner-proxmox
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: burrito-runner-proxmox
+    template:
+      engineVersion: v2
+      data:
+        TF_VAR_proxmox_api_token: '{{ "{{ .proxmoxApiToken }}" }}'
+        TF_VAR_ssh_public_key: '{{ "{{ .sshPublicKey }}" }}'
+        # runner pods are not on the tailnet, use the LAN endpoint
+        TF_VAR_proxmox_endpoint: https://192.168.1.30:8006
+  data:
+    - secretKey: proxmoxApiToken
+      remoteRef:
+        key: proxmox-api-token
+    - secretKey: sshPublicKey
+      remoteRef:
+        key: ssh-public-key

--- a/gitops/burrito-homelab/burrito-layers/templates/layer-proxmox.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/layer-proxmox.yaml
@@ -1,0 +1,24 @@
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: proxmox
+spec:
+  path: terraform/proxmox
+  branch: main
+  repository:
+    name: brassberry-gitops
+    namespace: burrito-homelab
+  # autoApply stays false forever: an apply here can recreate the VM worker
+  # hosted by the very Proxmox node this layer manages
+  remediationStrategy:
+    autoApply: false
+  overrideRunnerSpec:
+    # never schedule on k8s-worker-1 (the Proxmox-hosted VM, the only amd64 node)
+    nodeSelector:
+      kubernetes.io/arch: arm64
+    # arrays replace wholesale on merge, so re-list burrito-runner-common
+    envFrom:
+      - secretRef:
+          name: burrito-runner-common
+      - secretRef:
+          name: burrito-runner-proxmox


### PR DESCRIPTION
## What

The last layer: `proxmox`, plan-only **permanently** (`autoApply: false` set explicitly) — an apply there can recreate `k8s-worker-1`, the VM hosted by the very Proxmox node the layer manages.

Turned out much smaller than the v1 plan expected:

- **Zero Terraform changes.** `proxmox_endpoint` is already a variable — the runner secret overrides it to the LAN address (`https://192.168.1.30:8006`) since pods aren't on the tailnet. The provider's `ssh {}` block (agent, jonbonas hostname) is only exercised at apply time, which this layer never does, so the v1 plan's SSH variable surgery and private-key mount are unnecessary.
- **`burrito-runner-proxmox`** ExternalSecret: `TF_VAR_proxmox_api_token` + `TF_VAR_ssh_public_key` from the existing BWS entries, plus the endpoint literal.
- **Runner pinning**: `kubernetes.io/arch: arm64` instead of a single-hostname pin — the only amd64 node is `k8s-worker-1` (the forbidden one), so any Pi is a valid target and no single Pi becomes a scheduling SPOF.

## Expected first plan

This root has known pre-existing drift: `ubuntu_cloud_image` must be replaced (newer upstream image) + one VM in-place update. The layer will surface it, same as the cloud layer surfaces its image-rebuild diff. Reconciling that drift is a separate local apply decision.

## After merge

Nothing manual: both BWS entries already exist and are ESO-adopted. ArgoCD syncs, the webhook (now healthy) triggers the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)