### PR TITLE
feat(burrito): phase 5, autoApply on the scaleway layer

### DIFF
--- a/gitops/burrito-homelab/burrito-layers/templates/layer-scaleway.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/layer-scaleway.yaml
@@ -8,6 +8,8 @@ spec:
   repository:
     name: brassberry-gitops
     namespace: burrito-homelab
+  remediationStrategy:
+    autoApply: true
   overrideRunnerSpec:
     # arrays replace wholesale on merge, so re-list burrito-runner-common
     envFrom:

--- a/terraform/scaleway/burrito_runner.tf
+++ b/terraform/scaleway/burrito_runner.tf
@@ -9,24 +9,21 @@ resource "scaleway_iam_application" "burrito_runner" {
 
 resource "scaleway_iam_policy" "burrito_runner" {
   name           = "burrito-runner"
-  description    = "Plan-only: read everything, write Object Storage on the default project (tfstates backend + locks)"
+  description    = "autoApply on the scaleway layer: manage IAM/projects/Object Storage, read the rest"
   application_id = scaleway_iam_application.burrito_runner.id
 
   # A rule cannot mix scope types: org-scope sets (IAM, projects) and
   # projects-scope sets (products) go in separate rules.
+  # IAMManager means this key can escalate its own permissions (documented
+  # Scaleway caveat), accepted for autoApply on the scaleway root.
   rule {
     organization_id      = data.scaleway_account_project.homelab.organization_id
-    permission_set_names = ["IAMReadOnly", "ProjectReadOnly"]
+    permission_set_names = ["IAMManager", "ProjectManager"]
   }
 
   rule {
     organization_id      = data.scaleway_account_project.homelab.organization_id
-    permission_set_names = ["AllProductsReadOnly"]
-  }
-
-  rule {
-    project_ids          = [data.scaleway_account_project.homelab.id]
-    permission_set_names = ["ObjectStorageFullAccess"]
+    permission_set_names = ["AllProductsReadOnly", "ObjectStorageFullAccess"]
   }
 }
 


### PR DESCRIPTION
Final phase of the burrito rollout: `autoApply: true` on the **scaleway layer only** (cloud stays plan-only until its image rebuild is decided, proxmox stays plan-only forever).

- The `burrito-runner` policy widens from read-only to managing what the scaleway root owns: `IAMManager` + `ProjectManager` (org scope), `ObjectStorageFullAccess` on all projects, `AllProductsReadOnly` for the rest. The IAMManager escalation caveat is documented inline and accepted for this root.
- **Already applied locally** (plan now clean): the runner can't grant itself the write permissions it needs to apply, so infra had to lead config here.
- Webhook verified live earlier, so merges to main now plan instantly, and scaleway changes apply automatically after a green plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)