### PR TITLE
feat(burrito): autoApply on the cloud layer with a tooled runner image

### DIFF
--- a/.github/workflows/build-burrito-runner.yaml
+++ b/.github/workflows/build-burrito-runner.yaml
@@ -33,6 +33,14 @@ jobs:
         id: burrito
         run: echo "version=$(sed -n 's|^FROM ghcr.io/padok-team/burrito:\([^@ ]*\).*|\1|p' images/burrito-runner/Dockerfile)" >> "$GITHUB_OUTPUT"
 
+      - name: Check the chart and the cloud layer pin the same burrito version
+        run: |
+          version="${{ steps.burrito.outputs.version }}"
+          grep -q "version: \"${version#v}\"" gitops/burrito-system/burrito/Chart.yaml || {
+            echo "Chart.yaml does not pin burrito ${version#v}"; exit 1; }
+          grep -q "image: ghcr.io/dixneuf19/burrito-runner:${version}$" gitops/burrito-homelab/burrito-layers/templates/layer-cloud.yaml || {
+            echo "layer-cloud.yaml does not pin burrito-runner:${version}"; exit 1; }
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/build-burrito-runner.yaml
+++ b/.github/workflows/build-burrito-runner.yaml
@@ -1,0 +1,67 @@
+name: Build burrito runner image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - images/burrito-runner/**
+      - .github/workflows/build-burrito-runner.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - images/burrito-runner/**
+      - .github/workflows/build-burrito-runner.yaml
+  workflow_dispatch:
+
+env:
+  TARGET_PLATFORMS: linux/amd64,linux/arm64
+  REGISTRY: ghcr.io
+  IMAGE_NAME: dixneuf19/burrito-runner
+
+jobs:
+  build_and_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Extract the burrito version from the base image tag
+        id: burrito
+        run: echo "version=$(sed -n 's|^FROM ghcr.io/padok-team/burrito:\([^@ ]*\).*|\1|p' images/burrito-runner/Dockerfile)" >> "$GITHUB_OUTPUT"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.burrito.outputs.version }}
+            type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: images/burrito-runner
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ env.TARGET_PLATFORMS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/gitops/burrito-homelab/burrito-layers/templates/layer-cloud.yaml
+++ b/gitops/burrito-homelab/burrito-layers/templates/layer-cloud.yaml
@@ -8,7 +8,11 @@ spec:
   repository:
     name: brassberry-gitops
     namespace: burrito-homelab
+  remediationStrategy:
+    autoApply: true
   overrideRunnerSpec:
+    # default runner + curl/jq/nc for the local-exec scripts (images/burrito-runner)
+    image: ghcr.io/dixneuf19/burrito-runner:v0.13.0
     # arrays replace wholesale on merge, so re-list burrito-runner-common
     envFrom:
       - secretRef:

--- a/images/burrito-runner/Dockerfile
+++ b/images/burrito-runner/Dockerfile
@@ -1,0 +1,8 @@
+FROM ghcr.io/padok-team/burrito:v0.13.0
+
+USER root
+# Tools for the terraform/cloud local-exec scripts (tailnet-adopt.sh, public-check.sh).
+# Keep this tag in sync with the chart version in gitops/burrito-system/burrito/Chart.yaml
+# and the runner image tag in gitops/burrito-homelab/burrito-layers/templates/layer-cloud.yaml.
+RUN apk add --update --no-cache curl jq netcat-openbsd
+USER 65532:65532

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>dixneuf19/renovate-presets"]
+  "extends": ["local>dixneuf19/renovate-presets"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the burrito-runner tag in the cloud layer; it mirrors upstream burrito versions",
+      "managerFilePatterns": [
+        "/gitops/burrito-homelab/burrito-layers/templates/layer-cloud\\.yaml$/"
+      ],
+      "matchStrings": [
+        "image: ghcr\\.io/dixneuf19/burrito-runner:(?<currentValue>[^\\s@]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/padok-team/burrito"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Bump the burrito chart, the runner base image and the layer image tag in one PR",
+      "groupName": "burrito",
+      "matchPackageNames": ["burrito", "ghcr.io/padok-team/burrito"]
+    }
+  ]
 }

--- a/terraform/cloud/README.md
+++ b/terraform/cloud/README.md
@@ -45,6 +45,13 @@ fails the apply if nginx does not accept TCP on the public 80/443 within
 5 minutes. To force a rebuild of a broken VM:
 `terraform apply -replace=random_id.hostname_suffix`.
 
+The Burrito layer runs with `autoApply: true` on a custom runner image
+(`images/burrito-runner`: the official burrito image plus curl, jq and
+netcat-openbsd for the scripts above), built by the `build-burrito-runner`
+GitHub workflow and published to `ghcr.io/dixneuf19/burrito-runner` with the
+burrito version as tag. One-time step after the first build: make the package
+public in its GitHub settings so the cluster pulls it anonymously.
+
 One-time setup for the provider credentials:
 
 1. Create an OAuth client in the

--- a/terraform/cloud/tailscale.tf
+++ b/terraform/cloud/tailscale.tf
@@ -1,6 +1,6 @@
 # Post-swap adoption: stable tailnet name for the new device, stale sibling
-# records deleted. Runs where terraform runs (needs bash, curl, jq), fine
-# while the layer is applied from the laptop; revisit before any autoApply.
+# records deleted. Runs where terraform runs and needs bash, curl, jq: present
+# on the laptop, and in the burrito runner via images/burrito-runner.
 resource "terraform_data" "tailnet_adopt" {
   triggers_replace = oci_core_instance.oracle-arm.id
 


### PR DESCRIPTION
## What

Turns `autoApply: true` back on for the cloud layer, this time with a runner image that can actually run the layer's local-exec steps.

- The default burrito runner image (alpine + bash/git/ssh only) lacks `curl` and `jq` (needed by `tailnet-adopt.sh`) and its busybox `nc` has no `-z` (needed by `public-check.sh`). Plans never execute provisioners, so plan-only worked; applies would not.
- `images/burrito-runner/Dockerfile`: `FROM ghcr.io/padok-team/burrito:v0.13.0` + `apk add curl jq netcat-openbsd`. Renovate bumps the pinned base via the shared presets; the tag must move together with the chart version in `gitops/burrito-system/burrito/Chart.yaml` and the image tag in `layer-cloud.yaml` (cross-referenced in the Dockerfile).
- `build-burrito-runner` workflow (modeled on fip-telegram-bot's): metadata-action, multi-arch amd64+arm64, GHCR with `GITHUB_TOKEN`, push skipped on PR events, tag = burrito version extracted from the `FROM` line.
- The cloud layer sets `overrideRunnerSpec.image` to `ghcr.io/dixneuf19/burrito-runner:v0.13.0` and `remediationStrategy.autoApply: true`.

## What autoApply arms

Unattended from now on: blue/green VM rebuilds on new Oracle Ubuntu images (`available_images` keeper) and the 90-day `tailscale_tailnet_key` rotation (key-only, no rebuild). Each swap is guarded by the tailnet adoption step (stable `oracle-arm` name, stale device cleanup) and the public TCP reachability check, both tested live on 2026-08-17.

## Merge order

1. Based on #1691, merge that one first (its commits show here until then).
2. The PR build validates the Dockerfile without pushing (`workflow_dispatch` only works once the workflow is on main). After merging: the push-to-main run publishes the image, then one-time, make the `burrito-runner` package public in its GitHub package settings. Until both are done the cloud runner pod sits in ImagePullBackOff; burrito recovers on its own once the pull succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)