### PR TITLE
fix(traefik): let the chart render without Prometheus Operator CRDs

### DIFF
--- a/gitops/traefik/traefik/values.yaml
+++ b/gitops/traefik/traefik/values.yaml
@@ -35,6 +35,10 @@ traefik:
 
   metrics:
     prometheus:
+      # The chart hard-fails rendering when monitoring.coreos.com/v1 is absent.
+      # The CI diff-preview cluster has no Prometheus Operator, so keep the
+      # ServiceMonitor renderable there; the real cluster has the CRD.
+      disableAPICheck: true
       entryPoint: metrics
       service:
         enabled: true


### PR DESCRIPTION
## Problem

Every traefik PR fails the `build` check with `❌ Failed to extract resources`, and it is not the PR's fault. The traefik chart hard-fails rendering when `metrics.prometheus.serviceMonitor.enabled` is true but `monitoring.coreos.com/v1` is not registered in the target cluster:

```
Error: execution error at (traefik/charts/traefik/templates/servicemonitor.yaml:5:10):
ERROR: You have to deploy monitoring.coreos.com/v1 first
```

The Argo CD diff preview creates a bare kind cluster with no Prometheus Operator, so the traefik app is unrenderable there. This happens on the **base** branch too, which I reproduced against unmodified `main`, so it is not a regression from any single PR. Net effect: our ingress controller is the one app that never gets a rendered diff before merge.

kube-prometheus-stack is unaffected because it ships its own CRDs and templates ServiceMonitors unconditionally. Only traefik does this defensive capability check.

## Fix

`disableAPICheck: true` is the chart's own escape hatch for exactly this case. It skips the render-time guard only:

- the ServiceMonitor is still emitted, unchanged
- the real cluster has the CRD, so nothing changes at apply time
- it also unbreaks a plain `make template` in `gitops/traefik/traefik`

## Verification

`helm template` with no CRDs present, against both the current chart and the pending v41:

| chart | before | after | ServiceMonitor emitted |
|---|---|---|---|
| 39.0.9 (current) | fails | renders | yes |
| 41.2.0 (#1657) | fails | renders | yes |

`--log.level=INFO` is preserved in both.

## Follow-up

Once this merges, #1657 (traefik v41) can be rebased and should finally produce a real diff instead of a render error.