### PR TITLE
feat(karakeep): enable semantic search via mistral-embed

### DIFF
--- a/gitops/karakeep/karakeep/values.yaml
+++ b/gitops/karakeep/karakeep/values.yaml
@@ -75,6 +75,9 @@ env:
   INFERENCE_TEXT_MODEL: "mistral-small-latest"
   INFERENCE_IMAGE_MODEL: "mistral-small-latest"
   INFERENCE_JOB_TIMEOUT_SEC: "120"
+  EMBEDDING_TEXT_MODEL: "mistral-embed"
+  EMBEDDING_DIMENSIONS: "1024" # Fixed for mistral-embed; changing it forces a full re-embed
+  EMBEDDING_ENABLE_AUTO_INDEXING: "true" # Only defaults to true on stock OpenAI, so semantic search stays off without it
 
 # Secrets imported as environment variables
 secretEnvVars:


### PR DESCRIPTION
## Why

Semantic and hybrid search are silently off on the instance. The API confirms it:

```
search-bookmarks(searchMode: "semantic") → "Semantic search is not enabled"
```

Karakeep 0.33 gates the feature on `SEMANTIC_SEARCH_ENABLED && embedding.enableAutoIndexing && embedding.isConfigured`. Our `OPENAI_API_KEY` makes `isConfigured` true, but `enableAutoIndexing` only defaults to true on stock OpenAI. Because `OPENAI_BASE_URL` points at Mistral, it falls back to false and the chain collapses. Meilisearch has already created the `bookmarks_vectors` index, it just holds nothing:

```
bookmarks:         1602 docs, 385 MB
bookmarks_vectors:    0 docs,  48 KB
```

Two consequences today:

- **Search is purely lexical.** A query only matches words that literally appear in the title or content, so meaning-based lookups fail and API consumers have to fall back on `#tag` / `list:` / `is:` qualifiers.
- **Auto-tagging runs blind.** Since 0.33, Karakeep uses embeddings to find semantically similar bookmarks and offers their existing tags to the LLM as candidates. Without vectors every bookmark is tagged in isolation, which is how a library accumulates `k8s`, `kubernetes` and `k8s-networking` as three separate tags.

## What

Three env vars, no new provider, no new secret.

`mistral-embed` is already available on the existing Mistral key, verified against the live API: `/v1/models` lists it and `/v1/embeddings` returns 1024 dimensions. Meilisearch is 1.53.1, well past the 1.13 minimum, and the vector store is GA so no experimental flag is needed.

`EMBEDDING_CONTEXT_LENGTH` stays at its 8000 default, which matches mistral-embed's 8192 window. `EMBEDDING_TEXT_MODEL_DIMENSION_OVERRIDE` is deliberately unset since mistral-embed is fixed at 1024.

## Cost and footprint

| | |
|---|---|
| Backfill | ~7M tokens for 1602 bookmarks, under \$1 one-off at \$0.10/M |
| Ongoing | new bookmarks only, cents per year |
| Storage | 1602 × 1024 × 4B ≈ 7Mi of vectors plus HNSW overhead, on a Meilisearch volume with 1.6T free |
| Memory | negligible against the 1Gi Meilisearch limit |

## After merge

Backfill is not automatic. Once ArgoCD has rolled the deployment, go to Admin Settings → Background Jobs → Embeddings and regenerate for all bookmarks.

## Notes

- **The model choice is sticky.** Changing the model or its dimension after even one bookmark is embedded forces a full re-embed of all 1602.
- **Meilisearch is not in the backup.** `files/backup.sh` covers `db.db` and `assets` only. Losing that volume already cost a reindex; it now also costs a re-embed. That is under a dollar, so it is a note rather than a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)