### PR TITLE
revert(karakeep): disable semantic search, mistral-embed is incompatible

### DIFF
--- a/gitops/karakeep/karakeep/values.yaml
+++ b/gitops/karakeep/karakeep/values.yaml
@@ -75,9 +75,6 @@ env:
   INFERENCE_TEXT_MODEL: "mistral-small-latest"
   INFERENCE_IMAGE_MODEL: "mistral-small-latest"
   INFERENCE_JOB_TIMEOUT_SEC: "120"
-  EMBEDDING_TEXT_MODEL: "mistral-embed"
-  EMBEDDING_DIMENSIONS: "1024" # Fixed for mistral-embed; changing it forces a full re-embed
-  EMBEDDING_ENABLE_AUTO_INDEXING: "true" # Only defaults to true on stock OpenAI, so semantic search stays off without it
 
 # Secrets imported as environment variables
 secretEnvVars:


### PR DESCRIPTION
Reverts #1717.

## What went wrong

The config itself was right. ArgoCD rolled it, the worker started, and Meilisearch accepted the embedder:

```
Starting embeddings worker ...
[meilisearch-vector] Configuring user-provided embedder
→ bookmarks_vectors embedder = {"source": "userProvided", "dimensions": 1024}
```

But no embedding can actually be produced. `searchMode=semantic` now 500s:

```
MeilisearchApiError: Invalid vector dimensions: expected: `1024`, found: `256`.
  url: 'http://karakeep-meilisearch:7700/indexes/bookmarks_vectors/search'
```

## Root cause

Not our config, an SDK/provider incompatibility:

1. Karakeep calls `openai.embeddings.create({model, input})` with no `encoding_format` (`packages/shared/inference.ts:249`).
2. openai-node 6.34.0 silently injects `encoding_format: "base64"`, commented in the SDK as *"No encoding_format specified, defaulting to base64 for performance reasons"*.
3. Mistral ignores the parameter and returns a plain JSON array of 1024 floats. Verified live against our key: `POST /v1/embeddings {"encoding_format":"base64"}` → `type: list, len: 1024`.
4. The SDK assumes base64 came back and runs `Buffer.from(embedding, 'base64')`. Given an array rather than a string, Node ignores the encoding and coerces to octets: 1024 numbers → 1024 bytes.
5. `new Float32Array(buf)` over 1024 bytes → 256 elements.

Reproduced standalone:

```
Buffer.from(numberArray, "base64") bytes: 1024
as Float32Array: 256
```

Note that `EMBEDDING_DIMENSIONS=256` would silence Meilisearch but store **garbage**: those 256 floats are the original float values reinterpreted as raw bytes, so search would return random results instead of erroring, which is worse.

Same class of bug as [mem0#4057](https://github.com/mem0ai/mem0/issues/4057), [honcho#932](https://github.com/plastic-labs/honcho/issues/932), [langchainjs#8221](https://github.com/langchain-ai/langchainjs/issues/8221) and [mcphub#592](https://github.com/samanhappy/mcphub/issues/592), the last reporting the identical 1024 → 256 corruption.

## Why not just switch provider

Ollama is immune since it uses the `ollama` SDK rather than openai-node, but it is unreachable from our setup. `EmbeddingClientFactory.build()` falls through to `InferenceClientFactory.build()`, which always prefers OpenAI:

```js
if (serverConfig.inference.openAIApiKey) return OpenAIInferenceClient.fromConfig();
if (serverConfig.inference.ollamaBaseUrl) return OllamaInferenceClient.fromConfig();
```

And pointing `EMBEDDING_OPENAI_BASE_URL` at Ollama routes back through `OpenAIEmbeddingClient` and the same base64 path. Karakeep 0.33.2 is the latest release and upstream `main` has no `encoding_format` handling, so there is no version to upgrade into.

## Why revert rather than leave it

Reverting restores the clean "Semantic search is not enabled" error instead of a 500, and stops `EMBEDDING_ENABLE_AUTO_INDEXING=true` spending a failed Mistral call on every new bookmark.

Nothing to clean up: `bookmarks_vectors` is still at 0 documents and the backfill was never run.

## Follow-up

The real fix is upstream, passing an explicit `encoding_format`. An issue and PR against karakeep-app/karakeep will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)