### PR TITLE
feat(miniserve): switch cd-lna and files to the official image

### DIFF
--- a/gitops/default/cd-lna/manifests/cd-lna.yaml
+++ b/gitops/default/cd-lna/manifests/cd-lna.yaml
@@ -13,12 +13,24 @@ spec:
     spec:
       containers:
       - name: cd-lna
-        image: dixneuf19/miniserve:v0.10.3-aarch64
+        image: docker.io/svenstaro/miniserve:0.35.0
         args:
           - "--enable-tar"
+          - "--enable-tar-gz"
+          - "--compress-response"
+          - "--dirs-first"
+          - "--hide-version-footer"
           - "--qrcode"
           - "--verbose"
           - "/tmp"
+        readinessProbe:
+          httpGet:
+            path: /__miniserve_internal/healthcheck
+            port: 8080
+        livenessProbe:
+          httpGet:
+            path: /__miniserve_internal/healthcheck
+            port: 8080
         volumeMounts:
         - name: cd-lna
           mountPath: /tmp/cd-lna

--- a/gitops/netflix/files/files.yaml
+++ b/gitops/netflix/files/files.yaml
@@ -13,12 +13,24 @@ spec:
     spec:
       containers:
       - name: files
-        image: dixneuf19/miniserve:v0.10.3-aarch64
+        image: docker.io/svenstaro/miniserve:0.35.0
         args:
           - "--enable-tar"
+          - "--enable-tar-gz"
+          - "--compress-response"
+          - "--dirs-first"
+          - "--hide-version-footer"
           - "--qrcode"
           - "--verbose"
           - "/tmp"
+        readinessProbe:
+          httpGet:
+            path: /__miniserve_internal/healthcheck
+            port: 8080
+        livenessProbe:
+          httpGet:
+            path: /__miniserve_internal/healthcheck
+            port: 8080
         volumeMounts:
         - name: media
           mountPath: /tmp/media


### PR DESCRIPTION
Replaces `dixneuf19/miniserve:v0.10.3-aarch64` with `docker.io/svenstaro/miniserve:0.35.0` on both `cd-lna` and `files`.

Upstream now publishes multi-arch manifests (`linux/amd64`, `linux/arm`, `linux/arm64`), so the custom single-arch build and the `-aarch64` suffix are no longer needed. The `Containerfile` is `FROM debian:testing-slim` with `ENTRYPOINT ["/app/miniserve"]`, so the existing `args:` list passes straight through and it runs as root exactly like the old image did.

## Breaking change handled

v0.10.3 is from Nov 2020, so this jumps 25 minor releases. One change affects us: since 0.14.0 `--enable-tar` was split in two. In v0.10.3 the single flag gated both archive links (`archive.rs:58-59`: `TarGz => tar_enabled, Tar => tar_enabled`); now `-r/--enable-tar` is the uncompressed tarball only and `-g/--enable-tar-gz` is the gzipped one. Without adding the second flag, the `.tar.gz` download button would silently disappear.

The 0.13.0 startup guard ("refuse to start without explicit path and interactive terminal attachment") does not bite because both Deployments pass `/tmp` explicitly. Worth remembering if anyone ever drops that arg: the pod would crash-loop with no TTY.

Verified unchanged against the v0.35.0 source: default port 8080, bind-all default, `--qrcode` and `--verbose` same names, and the default sort still resolves to A-Z (`desc` is the non-reversed branch in `listing.rs:388`).

## Security fixes picked up

Relevant because `cd-lna.dixneuf19.fr` is publicly exposed with no auth middleware:

- 0.12.0: DoS via non-conforming URL paths
- 0.19.4: random route leaking on error pages
- 0.19.5: `--no-symlinks` hid symlinks but did not prevent access to them
- 0.25.0: illegal request path crashing the process

The write-side features added upstream since (`--upload-files`, `--mkdir`, `--rm-files`, `--pastebin`, `--enable-webdav`) all default to off, so the upgrade adds no new write surface.

## Other flags added

- Probes on `/__miniserve_internal/healthcheck`, the well-known route added in 0.30.0. Neither Deployment had any probe before.
- `--compress-response` (0.27.0), both apps are served over the internet.
- `--dirs-first` and `--hide-version-footer`.

`--directory-size` (0.30.0) is deliberately left off: the recursive size counting would be expensive over the `media-nfs` mount on `files`.

## Verification

No Docker daemon available locally, so the check is static rather than a live container run: all seven flags confirmed present in `src/args.rs` at tag `v0.35.0`, the healthcheck path confirmed as `/__miniserve_internal/healthcheck` in `src/config.rs:244`, and both manifests parse as valid YAML. The ArgoCD diff job on this PR should be the real confirmation, and a quick `.tar.gz` download check after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)