### PR TITLE
chore(lms): unpin lyrion from arm64 instead of counter-pinning it

### DIFF
--- a/gitops/lms-yoshi/radioyoshi/values.yaml
+++ b/gitops/lms-yoshi/radioyoshi/values.yaml
@@ -1,8 +1,9 @@
 lyrion-music-server:
   common:
     podOptions:
-      nodeSelector:
-        kubernetes.io/arch: "arm64"
+      # TrueCharts' common library defaults this to amd64, which would pin the
+      # pod to the single VM worker. Must be null, not {}, to actually override.
+      nodeSelector: null
   TZ: "America/Bogota" # Quito timezone
   workload:
     main:

--- a/gitops/lms/lyrion-music-server/values.yaml
+++ b/gitops/lms/lyrion-music-server/values.yaml
@@ -1,8 +1,9 @@
 lyrion-music-server:
   common:
-    podOptions:  
-      nodeSelector:
-        kubernetes.io/arch: "arm64"
+    podOptions:
+      # TrueCharts' common library defaults this to amd64, which would pin the
+      # pod to the single VM worker. Must be null, not {}, to actually override.
+      nodeSelector: null
   TZ: "Europe/Paris"
   workload:
     main:


### PR DESCRIPTION
The `arm64` nodeSelector on both Lyrion charts was not a preference. The TrueCharts `common` library hardcodes `kubernetes.io/arch: "amd64"` as its default `podOptions.nodeSelector` (`charts/common/values.yaml:155`). On the Pi-only cluster of Oct 2024 that default made the pod unschedulable, so the `arm64` override was the fix, not a constraint.

Now that the cluster is mixed (4x arm64 Pi + 1x amd64 VM), neither value is correct. Nothing about Lyrion needs a specific arch:

- `lmscommunity/lyrionmusicserver:9.2.0` ships both `linux/amd64` and `linux/arm64`
- the config PVC is NFS-backed (`nfs-client`) with no node affinity on the PV
- the shared MetalLB IP `192.168.1.19` is announced in L2 from whichever node runs the pod, and `k8s-worker-1` is bridged onto the same `192.168.1.0/24` as the Pis, inside the pool range `192.168.1.3-30`

So both charts now let the scheduler pick freely across all 5 nodes.

### Why `null` and not `{}`

Helm coalesces an empty map back to the subchart default, so `nodeSelector: {}` renders the `amd64` pin unchanged. Verified with `helm template` on both charts: `null` is the only form that actually clears it.

### Not touched: the burrito `proxmox` layer

Its `arm64` pin looks similar but is load-bearing and stays. That layer runs `terraform/proxmox`, which owns `proxmox_virtual_environment_vm.k8s_worker` (`terraform/proxmox/vms.tf:6-8`), the VM that *is* `k8s-worker-1`. The selector is being used as a proxy for "never schedule on the node this layer can destroy", and the existing comment says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)